### PR TITLE
[#70] 마이페이지 내글목록 탭 구현

### DIFF
--- a/src/components/myPage/myPostsTab/MyPostsTab.stories.tsx
+++ b/src/components/myPage/myPostsTab/MyPostsTab.stories.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Story } from '@storybook/react';
+import MyPostsTab from './MyPostsTab';
+
+export default {
+  title: 'MyPage/PostsTab',
+  component: MyPostsTab,
+};
+
+const Template: Story = (args) => <MyPostsTab {...args} />;
+
+export const Default = Template.bind({});

--- a/src/components/myPage/myPostsTab/MyPostsTab.style.tsx
+++ b/src/components/myPage/myPostsTab/MyPostsTab.style.tsx
@@ -1,16 +1,12 @@
 import styled from '@emotion/styled';
-
+import { TEXT_STYLES } from '@/styles/constants/textStyles';
 interface TabFontBoxProps {
   isSelected: boolean;
 }
 
 export const TabFontBox = styled.div<TabFontBoxProps>`
-  font-family: 'Pretendard';
   font-style: normal;
-  font-weight: 500;
-  font-size: 15px;
   line-height: 210%;
-  letter-spacing: -0.011em;
   text-align: center;
   position: relative;
   width: 195px;
@@ -30,7 +26,7 @@ export const Rectangle242 = styled.div`
   left: 0px;
   top: 107px;
   padding-top : 4px;
-
+  ${TEXT_STYLES.BodyR16};
 `;
 
 export const TabContents = styled.div`

--- a/src/components/myPage/myPostsTab/MyPostsTab.style.tsx
+++ b/src/components/myPage/myPostsTab/MyPostsTab.style.tsx
@@ -9,7 +9,7 @@ export const TabFontBox = styled.div<TabFontBoxProps>`
   line-height: 210%;
   text-align: center;
   position: relative;
-  width: 195px;
+  width: 50%;
   height: 36px;
   display: inline-block;
   color: ${(props) => (props.isSelected ? '#5EBEEB' : '#313131')};
@@ -19,9 +19,8 @@ export const TabFontBox = styled.div<TabFontBoxProps>`
 
 export const Rectangle242 = styled.div`
   box-sizing: border-box;
-
   position: absolute;
-  width: 390px;
+  width: 100%;
   height: 40px;
   left: 0px;
   top: 107px;

--- a/src/components/myPage/myPostsTab/MyPostsTab.style.tsx
+++ b/src/components/myPage/myPostsTab/MyPostsTab.style.tsx
@@ -32,3 +32,8 @@ export const Rectangle242 = styled.div`
   padding-top : 4px;
 
 `;
+
+export const TabContents = styled.div`
+  top: 200px;
+  position: absolute;
+`;

--- a/src/components/myPage/myPostsTab/MyPostsTab.style.tsx
+++ b/src/components/myPage/myPostsTab/MyPostsTab.style.tsx
@@ -1,0 +1,34 @@
+import styled from '@emotion/styled';
+
+interface TabFontBoxProps {
+  isSelected: boolean;
+}
+
+export const TabFontBox = styled.div<TabFontBoxProps>`
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 500;
+  font-size: 15px;
+  line-height: 210%;
+  letter-spacing: -0.011em;
+  text-align: center;
+  position: relative;
+  width: 195px;
+  height: 36px;
+  display: inline-block;
+  color: ${(props) => (props.isSelected ? '#5EBEEB' : '#313131')};
+  border-bottom: 2px solid
+  ${(props) => (props.isSelected ? '#5EBEEB' : '#D9D9D9')};
+`;
+
+export const Rectangle242 = styled.div`
+  box-sizing: border-box;
+
+  position: absolute;
+  width: 390px;
+  height: 40px;
+  left: 0px;
+  top: 107px;
+  padding-top : 4px;
+
+`;

--- a/src/components/myPage/myPostsTab/MyPostsTab.style.tsx
+++ b/src/components/myPage/myPostsTab/MyPostsTab.style.tsx
@@ -17,7 +17,7 @@ export const TabFontBox = styled.div<TabFontBoxProps>`
   ${(props) => (props.isSelected ? '#5EBEEB' : '#D9D9D9')};
 `;
 
-export const Rectangle242 = styled.div`
+export const TabBox = styled.div`
   box-sizing: border-box;
   position: absolute;
   width: 100%;

--- a/src/components/myPage/myPostsTab/MyPostsTab.tsx
+++ b/src/components/myPage/myPostsTab/MyPostsTab.tsx
@@ -33,9 +33,9 @@ const MyPostsTab = () => {
           </styles.TabFontBox>
         ))}
       </styles.Rectangle242>
-      <p style={{ top: '200px', position: 'absolute' }}>
+      <styles.TabContents>
         {data[index].contents}
-      </p>
+      </styles.TabContents>
     </div>
   );
 };

--- a/src/components/myPage/myPostsTab/MyPostsTab.tsx
+++ b/src/components/myPage/myPostsTab/MyPostsTab.tsx
@@ -4,12 +4,10 @@ import * as styles from './MyPostsTab.style';
 const MyPostsTab = () => {
   const data = [
     {
-      id: 0,
       title: '글',
       contents: '글 목록!', // 컴포넌트 맞게 넣기 
     },
     {
-      id: 1,
       title: '댓글',
       contents: '댓글 목록!', // 컴포넌트 맞게 넣기 
     },
@@ -25,7 +23,7 @@ const MyPostsTab = () => {
       <styles.Rectangle242>
         {data.map((element, idx) => (
           <styles.TabFontBox
-            key={element.id}
+            key={idx}
             isSelected={idx === index}
             onClick={() => selectMenuHandler(idx)}
           >

--- a/src/components/myPage/myPostsTab/MyPostsTab.tsx
+++ b/src/components/myPage/myPostsTab/MyPostsTab.tsx
@@ -20,7 +20,7 @@ const MyPostsTab = () => {
 
   return (
     <div>
-      <styles.Rectangle242>
+      <styles.TabBox>
         {data.map((element, idx) => (
           <styles.TabFontBox
             key={idx}
@@ -30,7 +30,7 @@ const MyPostsTab = () => {
             {element.title}
           </styles.TabFontBox>
         ))}
-      </styles.Rectangle242>
+      </styles.TabBox>
       <styles.TabContents>
         {data[index].contents}
       </styles.TabContents>

--- a/src/components/myPage/myPostsTab/MyPostsTab.tsx
+++ b/src/components/myPage/myPostsTab/MyPostsTab.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import * as styles from './MyPostsTab.style';
+
+const MyPostsTab = () => {
+  const data = [
+    {
+      id: 0,
+      title: '글',
+      contents: '글 목록!', // 컴포넌트 맞게 넣기 
+    },
+    {
+      id: 1,
+      title: '댓글',
+      contents: '댓글 목록!', // 컴포넌트 맞게 넣기 
+    },
+  ];
+  const [index, setIndex] = useState(0);
+
+  const selectMenuHandler = (n: number) => {
+    setIndex(n);
+  };
+
+  return (
+    <div>
+      <styles.Rectangle242>
+        {data.map((element, idx) => (
+          <styles.TabFontBox
+            key={element.id}
+            isSelected={idx === index}
+            onClick={() => selectMenuHandler(idx)}
+          >
+            {element.title}
+          </styles.TabFontBox>
+        ))}
+      </styles.Rectangle242>
+      <p style={{ top: '200px', position: 'absolute' }}>
+        {data[index].contents}
+      </p>
+    </div>
+  );
+};
+
+export default MyPostsTab;


### PR DESCRIPTION
## Issue

- Resolves #70 

## Description

- 마이페이지 6-4 글/댓글 탭 구현 
- src/components/myPage/myPostsTab 안에 넣어뒀습니다..!
## Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  적절한 라벨 설정
- [x]  작업한 사람 모두를 Assign
- [x]  작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x]  `main` 브랜치의 최신 상태를 반영하고 있는지 확인

## Screenshot

![image](https://github.com/DaITssu/daitssu-client/assets/69834729/5b383344-6af2-45d3-83c6-6af310bda4e7)
