### PR TITLE
[#88] 0-2 로그인 페이지 UI 구현

### DIFF
--- a/src/components/common/InputBox/InputBox.stories.tsx
+++ b/src/components/common/InputBox/InputBox.stories.tsx
@@ -7,7 +7,6 @@ const meta: Meta<typeof InputBox> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     type: {
       control: 'radio',

--- a/src/components/common/InputBox/InputBox.stories.tsx
+++ b/src/components/common/InputBox/InputBox.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import InputBox from './InputBox';
+
+const meta: Meta<typeof InputBox> = {
+  title: 'InputBox',
+  component: InputBox,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    type: {
+      control: 'radio',
+      options: ['text', 'number', 'password'],
+    },
+    setValue: {
+      control: false,
+    },
+  },
+};
+export default meta;
+type Story = StoryObj<typeof InputBox>;
+
+export const Primary: Story = {
+  args: {
+    label: 'ID',
+    width: '360px',
+    height: '48px',
+    placeholder: '학번',
+    type: 'text',
+  },
+};

--- a/src/components/common/InputBox/InputBox.styles.ts
+++ b/src/components/common/InputBox/InputBox.styles.ts
@@ -34,7 +34,7 @@ export const Input = styled.input<{ width?: string; height?: string }>`
   color: ${COLORS.grayscale.Gray1};
   ${TEXT_STYLES.BodyR16};
 
-  //type='number'일 때 화살표 없애긴
+  //type='number'일 때 화살표 없애기
   &::-webkit-outer-spin-button,
   &::-webkit-inner-spin-button {
     -webkit-appearance: none;

--- a/src/components/common/InputBox/InputBox.styles.ts
+++ b/src/components/common/InputBox/InputBox.styles.ts
@@ -1,0 +1,43 @@
+import styled from '@emotion/styled';
+import { COLORS } from '@/styles/constants/colors';
+import { TEXT_STYLES } from '@/styles/constants/textStyles';
+import { css } from '@emotion/react';
+
+export const InputBoxContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+
+  padding: 12px 0;
+`;
+
+export const InputLabel = styled.label`
+  color: ${COLORS.grayscale.Gray1};
+  ${TEXT_STYLES.CapM14};
+
+  margin-bottom: 4px;
+`;
+
+export const Input = styled.input<{ width?: string; height?: string }>`
+  ${({ width = '358px', height = '48px' }) => css`
+    width: ${width};
+    height: ${height};
+  `}
+  padding: 12px;
+
+  background-color: white;
+  border-radius: 6px;
+  border: 1px solid ${COLORS.grayscale.Gray3};
+  outline: none;
+
+  color: ${COLORS.grayscale.Gray1};
+  ${TEXT_STYLES.BodyR16};
+
+  //type='number'일 때 화살표 없애긴
+  &::-webkit-outer-spin-button,
+  &::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+`;

--- a/src/components/common/InputBox/InputBox.tsx
+++ b/src/components/common/InputBox/InputBox.tsx
@@ -1,0 +1,34 @@
+import * as styles from './InputBox.styles';
+import { Dispatch, SetStateAction } from 'react';
+
+interface InputBoxProps {
+  width?: string;
+  height?: string;
+  label?: string;
+  type?: 'text' | 'number' | 'password';
+  placeholder?: string;
+  value: any;
+  setValue: Dispatch<SetStateAction<any>>;
+}
+
+export default function InputBox({ value, setValue, ...props }: InputBoxProps) {
+  const handleChangeInput = (e: React.FormEvent<HTMLInputElement>) => {
+    if (props.type === 'number' && e.currentTarget.value) {
+      setValue(Number(e.currentTarget.value));
+    } else setValue(e.currentTarget.value);
+  };
+  return (
+    <styles.InputBoxContainer>
+      <styles.InputLabel htmlFor={props.label}>{props.label}</styles.InputLabel>
+      <styles.Input
+        value={value || ''}
+        onChange={handleChangeInput}
+        id={props.label}
+        type={props.type}
+        width={props.width}
+        height={props.height}
+        placeholder={props.placeholder}
+      />
+    </styles.InputBoxContainer>
+  );
+}

--- a/src/components/login/AutoLogon/AutoLogon.styles.ts
+++ b/src/components/login/AutoLogon/AutoLogon.styles.ts
@@ -1,0 +1,29 @@
+import styled from '@emotion/styled';
+import { COLORS } from '@/styles/constants/colors';
+import { TEXT_STYLES } from '@/styles/constants/textStyles';
+
+export const AutoLogonContainer = styled.div`
+  display: flex;
+  align-items: center;
+
+  width: 100%;
+  margin-bottom: 24px;
+`;
+
+export const CheckBtn = styled.button`
+  width: 15px;
+  height: 15px;
+  margin-right: 8px;
+
+  background-color: transparent;
+  border: none;
+
+  &:hover {
+    cursor: pointer;
+  }
+`;
+
+export const Text = styled.div`
+  color: ${COLORS.grayscale.Gray2};
+  ${TEXT_STYLES.CapR14};
+`;

--- a/src/components/login/AutoLogon/AutoLogon.tsx
+++ b/src/components/login/AutoLogon/AutoLogon.tsx
@@ -6,19 +6,15 @@ import BlueCheckedBoxIcon from '@icons/icon/CheckBox/BlueCheckedBox.svg';
 
 interface AutoLogonProps {
   isSelected: boolean;
-  setIsSelected: React.Dispatch<React.SetStateAction<boolean>>;
+  handleClickAutoLogon: () => void;
 }
 export default function AutoLogon({
   isSelected,
-  setIsSelected,
+  handleClickAutoLogon,
 }: AutoLogonProps) {
-  const handleClickCheckBtn = () => {
-    setIsSelected(!isSelected);
-  };
-
   return (
     <styles.AutoLogonContainer>
-      <styles.CheckBtn onClick={handleClickCheckBtn}>
+      <styles.CheckBtn onClick={handleClickAutoLogon}>
         {isSelected ? (
           <Image src={BlueCheckedBoxIcon} alt="자동로그인 체크박스" />
         ) : (

--- a/src/components/login/AutoLogon/AutoLogon.tsx
+++ b/src/components/login/AutoLogon/AutoLogon.tsx
@@ -1,0 +1,31 @@
+import Image from 'next/image';
+
+import * as styles from './AutoLogon.styles';
+import GrayCheckedBoxIcon from '@icons/icon/CheckBox/GrayCheckedBox.svg';
+import BlueCheckedBoxIcon from '@icons/icon/CheckBox/BlueCheckedBox.svg';
+
+interface AutoLogonProps {
+  isSelected: boolean;
+  setIsSelected: React.Dispatch<React.SetStateAction<boolean>>;
+}
+export default function AutoLogon({
+  isSelected,
+  setIsSelected,
+}: AutoLogonProps) {
+  const handleClickCheckBtn = () => {
+    setIsSelected(!isSelected);
+  };
+
+  return (
+    <styles.AutoLogonContainer>
+      <styles.CheckBtn onClick={handleClickCheckBtn}>
+        {isSelected ? (
+          <Image src={BlueCheckedBoxIcon} alt="자동로그인 체크박스" />
+        ) : (
+          <Image src={GrayCheckedBoxIcon} alt="자동로그인 체크박스" />
+        )}
+      </styles.CheckBtn>
+      <styles.Text>자동로그인</styles.Text>
+    </styles.AutoLogonContainer>
+  );
+}

--- a/src/components/login/FindAuth/FindAuth.styles.ts
+++ b/src/components/login/FindAuth/FindAuth.styles.ts
@@ -1,0 +1,27 @@
+import styled from '@emotion/styled';
+import { COLORS } from '@/styles/constants/colors';
+import { TEXT_STYLES } from '@/styles/constants/textStyles';
+
+export const FindAuthContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+
+  width: 190px;
+  margin-top: 14px;
+`;
+
+export const FindIDPasswordBtn = styled.button`
+  color: ${COLORS.grayscale.Gray1};
+  ${TEXT_STYLES.CapR14}
+
+  background-color: transparent;
+  border: none;
+`;
+
+export const SignUpBtn = styled.button`
+  color: ${COLORS.SSU.primary};
+  ${TEXT_STYLES.CapR14}
+
+  background-color: transparent;
+  border: none;
+`;

--- a/src/components/login/FindAuth/FindAuth.tsx
+++ b/src/components/login/FindAuth/FindAuth.tsx
@@ -1,0 +1,26 @@
+import * as styles from './FindAuth.styles';
+import { useRouter } from 'next/router';
+
+//TODO: 라우터 맞게 수정
+export default function FindAuth() {
+  const router = useRouter();
+
+  const handleClickBtn = (type: 'find' | 'signup') => {
+    if (type === 'find') {
+      router.push('https://smartid.ssu.ac.kr/Symtra_Sso/smln_IDFind.asp');
+    } else if (type === 'signup') {
+      router.push('https://smartid.ssu.ac.kr/Symtra_Sso/smln_IDFind.asp');
+    }
+  };
+
+  return (
+    <styles.FindAuthContainer>
+      <styles.FindIDPasswordBtn onClick={() => handleClickBtn('find')}>
+        아이디/비밀번호 찾기
+      </styles.FindIDPasswordBtn>
+      <styles.SignUpBtn onClick={() => handleClickBtn('signup')}>
+        회원가입
+      </styles.SignUpBtn>
+    </styles.FindAuthContainer>
+  );
+}

--- a/src/components/login/LoginLayout/LoginLayout.styles.ts
+++ b/src/components/login/LoginLayout/LoginLayout.styles.ts
@@ -23,4 +23,6 @@ export const Content = styled.div`
 export const LoginHeader = styled.div`
   color: ${COLORS.SSU.primary};
   ${TEXT_STYLES.HeadSM20}
+
+  margin-bottom: 52px;
 `;

--- a/src/components/login/LoginLayout/LoginLayout.styles.ts
+++ b/src/components/login/LoginLayout/LoginLayout.styles.ts
@@ -1,0 +1,26 @@
+import styled from '@emotion/styled';
+import { COLORS } from '@/styles/constants/colors';
+import { TEXT_STYLES } from '@/styles/constants/textStyles';
+
+export const LayoutContainer = styled.div`
+  width: 100vw;
+  height: 100vh;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  background-color: white;
+`;
+
+export const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const LoginHeader = styled.div`
+  color: ${COLORS.SSU.primary};
+  ${TEXT_STYLES.HeadSM20}
+`;

--- a/src/components/login/LoginLayout/LoginLayout.tsx
+++ b/src/components/login/LoginLayout/LoginLayout.tsx
@@ -12,6 +12,10 @@ export default function LoginLayout() {
   const [isSelectedAutoLogon, setIsSelectedAutoLogon] =
     useState<boolean>(false);
 
+  const handleClickAutoLogon = () => {
+    setIsSelectedAutoLogon(!isSelectedAutoLogon);
+  };
+
   return (
     <styles.LayoutContainer>
       <styles.Content>
@@ -32,7 +36,7 @@ export default function LoginLayout() {
         />
         <AutoLogon
           isSelected={isSelectedAutoLogon}
-          setIsSelected={setIsSelectedAutoLogon}
+          handleClickAutoLogon={handleClickAutoLogon}
         />
         <Button label="로그인" height={51} />
         <FindAuth />

--- a/src/components/login/LoginLayout/LoginLayout.tsx
+++ b/src/components/login/LoginLayout/LoginLayout.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+import * as styles from './LoginLayout.styles';
+import InputBox from '@/components/common/InputBox/InputBox';
+
+export default function LoginLayout() {
+  const [ID, setID] = useState<number>();
+  const [password, setPassword] = useState<string>('');
+
+  return (
+    <styles.LayoutContainer>
+      <styles.Content>
+        <styles.LoginHeader>숭실대 통합 LOGIN</styles.LoginHeader>
+        <InputBox
+          value={ID}
+          setValue={setID}
+          label="ID"
+          type="number"
+          placeholder="학번"
+        />
+        <InputBox
+          value={password}
+          setValue={setPassword}
+          label="Password"
+          type="password"
+          placeholder="비밀번호"
+        />
+      </styles.Content>
+    </styles.LayoutContainer>
+  );
+}

--- a/src/components/login/LoginLayout/LoginLayout.tsx
+++ b/src/components/login/LoginLayout/LoginLayout.tsx
@@ -1,10 +1,16 @@
 import { useState } from 'react';
 import * as styles from './LoginLayout.styles';
+
 import InputBox from '@/components/common/InputBox/InputBox';
+import AutoLogon from '../AutoLogon/AutoLogon';
+import Button from '@/components/common/Button';
+import FindAuth from '../FindAuth/FindAuth';
 
 export default function LoginLayout() {
   const [ID, setID] = useState<number>();
   const [password, setPassword] = useState<string>('');
+  const [isSelectedAutoLogon, setIsSelectedAutoLogon] =
+    useState<boolean>(false);
 
   return (
     <styles.LayoutContainer>
@@ -24,6 +30,12 @@ export default function LoginLayout() {
           type="password"
           placeholder="비밀번호"
         />
+        <AutoLogon
+          isSelected={isSelectedAutoLogon}
+          setIsSelected={setIsSelectedAutoLogon}
+        />
+        <Button label="로그인" height={51} />
+        <FindAuth />
       </styles.Content>
     </styles.LayoutContainer>
   );

--- a/src/pages/login/index.page.tsx
+++ b/src/pages/login/index.page.tsx
@@ -1,0 +1,3 @@
+export default function Login() {
+  return <div>로그인</div>;
+}

--- a/src/pages/login/index.page.tsx
+++ b/src/pages/login/index.page.tsx
@@ -1,3 +1,5 @@
+import LoginLayout from '@/components/login/LoginLayout/LoginLayout';
+
 export default function Login() {
-  return <div>로그인</div>;
+  return <LoginLayout />;
 }


### PR DESCRIPTION
## Issue

- Resolves #88 

## Description

- 0-2 로그인 페이지 UI 부분 구현했습니다!
- Input 부분은 재사용할 수 있게 `common/InputBox` 컴포넌트로 구현했습니다. 근데 스토리북 페이지에서 에러가 나서 테스트는 아직 못해봤네요,,


## Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  적절한 라벨 설정
- [x]  작업한 사람 모두를 Assign
- [x]  작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x]  `main` 브랜치의 최신 상태를 반영하고 있는지 확인

## Screenshot

<img width="298" alt="image" src="https://github.com/DaITssu/daitssu-client/assets/70098708/70f38e1c-be73-4404-88f2-5bbb61e2655c">
