### PR TITLE
[#99] 0-3 아이디/비밀번호 찾기 페이지 

### DIFF
--- a/src/components/login/FindAccount/FindAccountLayout.styles.tsx
+++ b/src/components/login/FindAccount/FindAccountLayout.styles.tsx
@@ -1,0 +1,45 @@
+import styled from '@emotion/styled';
+import { COLORS } from '@/styles/constants/colors';
+import { TEXT_STYLES } from '@/styles/constants/textStyles';
+import { Button } from '@/components/common/Button/Button.styles';
+
+export const FindAccountLayout = styled.div`
+  width: 100vw;
+  height: 100vh;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  background-color: white;
+`;
+
+export const MessageContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  margin-bottom: 110px;
+`;
+
+export const FindAccountMessage = styled.div`
+  color: ${COLORS.SSU.primary};
+  ${TEXT_STYLES.HeadSM20};
+
+  margin-bottom: 16px;
+`;
+
+export const SubMessage = styled.div`
+  color: ${COLORS.grayscale.Gray1};
+  ${TEXT_STYLES.BodyM16}
+`;
+
+export const FindButton = styled(Button)`
+  background-color: white;
+  border: 1px solid ${COLORS.SSU.primary};
+  color: black;
+  ${TEXT_STYLES.HeadM18}
+
+  margin-bottom: 24px;
+`;

--- a/src/components/login/FindAccount/FindAccountLayout.tsx
+++ b/src/components/login/FindAccount/FindAccountLayout.tsx
@@ -4,10 +4,11 @@ import { useRouter } from 'next/router';
 export default function FindAccountLayout() {
   const router = useRouter();
 
-  //TODO: 라우터 맞게 수정
   const handleClickFindButton = (type: 'ID' | 'Password') => {
-    if (type === 'ID') router.push('/findId');
-    if (type === 'Password') router.push('/findPassword');
+    if (type === 'ID')
+      router.push('https://smartid.ssu.ac.kr/Symtra_Sso/smln_IDFind.asp');
+    if (type === 'Password')
+      router.push('https://smartid.ssu.ac.kr/Symtra_Sso/smln_pwd.asp');
   };
 
   return (

--- a/src/components/login/FindAccount/FindAccountLayout.tsx
+++ b/src/components/login/FindAccount/FindAccountLayout.tsx
@@ -1,0 +1,37 @@
+import * as styles from './FindAccountLayout.styles';
+import { useRouter } from 'next/router';
+
+export default function FindAccountLayout() {
+  const router = useRouter();
+
+  //TODO: 라우터 맞게 수정
+  const handleClickFindButton = (type: 'ID' | 'Password') => {
+    if (type === 'ID') router.push('/findId');
+    if (type === 'Password') router.push('/findPassword');
+  };
+
+  return (
+    <styles.FindAccountLayout>
+      <styles.MessageContainer>
+        <styles.FindAccountMessage>
+          아이디/비밀번호 찾기
+        </styles.FindAccountMessage>
+        <styles.SubMessage>찾으려는 정보를 선택해주세요</styles.SubMessage>
+      </styles.MessageContainer>
+      <styles.FindButton
+        onClick={() => {
+          handleClickFindButton('ID');
+        }}
+      >
+        아이디 찾기
+      </styles.FindButton>
+      <styles.FindButton
+        onClick={() => {
+          handleClickFindButton('Password');
+        }}
+      >
+        비밀번호 찾기
+      </styles.FindButton>
+    </styles.FindAccountLayout>
+  );
+}

--- a/src/components/login/FindAuth/FindAuth.tsx
+++ b/src/components/login/FindAuth/FindAuth.tsx
@@ -7,7 +7,7 @@ export default function FindAuth() {
 
   const handleClickBtn = (type: 'find' | 'signup') => {
     if (type === 'find') {
-      router.push('https://smartid.ssu.ac.kr/Symtra_Sso/smln_IDFind.asp');
+      router.push('/login/findAccount');
     } else if (type === 'signup') {
       router.push('https://smartid.ssu.ac.kr/Symtra_Sso/smln_IDFind.asp');
     }

--- a/src/pages/login/findAccount/index.page.tsx
+++ b/src/pages/login/findAccount/index.page.tsx
@@ -1,0 +1,5 @@
+import FindAccountLayout from '@/components/login/FindAccount/FindAccountLayout';
+
+export default function FindAccount() {
+  return <FindAccountLayout />;
+}


### PR DESCRIPTION
## Issue

- Resolves #99 

## Description

- 0-3 아이디/비밀번호 찾기 페이지 작업했습니다!
- 로그인 페이지에서 '아이디/비밀번호 찾기' 버튼 누르면 `/login/findAccount` 로 이동하게 됩니다

## Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  적절한 라벨 설정
- [x]  작업한 사람 모두를 Assign
- [x]  작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x]  `main` 브랜치의 최신 상태를 반영하고 있는지 확인

## Screenshot

<img width="311" alt="스크린샷 2023-09-25 오후 3 41 02" src="https://github.com/DaITssu/daitssu-client/assets/70098708/fd72c52e-4dff-4a8c-b5d8-f9badb02d218">

