### PR TITLE
[#112] 랜딩페이지 네이비게이션바 스크롤에 따라 렌더링

### DIFF
--- a/src/components/common/Navbar/NavItem.tsx
+++ b/src/components/common/Navbar/NavItem.tsx
@@ -17,9 +17,21 @@ const NavItem = ({ type, isFocused }: NavItemProps) => {
     <styles.IconContainer>
       <Link href={url}>
         {isFocused ? (
-          <Image src={Icon.active} width={24} height={24} alt="active" />
+          <Image
+            src={Icon.active}
+            width={24}
+            height={24}
+            alt="active"
+            priority
+          />
         ) : (
-          <Image src={Icon.default} width={24} height={24} alt="default" />
+          <Image
+            src={Icon.default}
+            width={24}
+            height={24}
+            alt="default"
+            priority
+          />
         )}
       </Link>
     </styles.IconContainer>

--- a/src/components/common/Navbar/NavigationBar.style.ts
+++ b/src/components/common/Navbar/NavigationBar.style.ts
@@ -1,14 +1,26 @@
-import { COLORS } from '../../../styles/constants/colors';
+import { COLORS } from '@/styles/constants/colors';
 import styled from '@emotion/styled';
-import { TEXT_STYLES } from '../../../styles/constants/textStyles';
 
-export const Navigaton = styled.div`
+export const Navigaton = styled.div<{ render: boolean }>`
   height: 100px;
   padding: 0 20px;
   display: flex;
   justify-content: space-between;
   align-items: center;
   background-color: ${COLORS.grayscale.white};
+  display: ${(props) => (props.render ? 'flex' : 'none')};
+
+  @keyframes fadeInUp {
+    0% {
+      opacity: 0;
+      transform: translate3d(0, 100%, 0);
+    }
+    to {
+      opacity: 1;
+      transform: translateZ(0);
+    }
+  }
+  animation: fadeInUp 0.5s;
 `;
 
 export const IconContainer = styled.div``;

--- a/src/components/common/Navbar/NavigationBar.tsx
+++ b/src/components/common/Navbar/NavigationBar.tsx
@@ -4,12 +4,13 @@ import NavItem from './NavItem';
 
 interface NavigationBarProps {
   focusType: keyof typeof NAV_LIST;
+  render: boolean;
 }
 
-const NavigationBar = ({ focusType }: NavigationBarProps) => {
+const NavigationBar = ({ focusType, render }: NavigationBarProps) => {
   return (
     <>
-      <styles.Navigaton>
+      <styles.Navigaton render={render}>
         <NavItem
           type={NAV_LIST.ANNOUNCEMENT}
           isFocused={focusType === NAV_LIST.ANNOUNCEMENT}

--- a/src/components/main/index.tsx
+++ b/src/components/main/index.tsx
@@ -1,7 +1,13 @@
+import styled from '@emotion/styled';
+
+const StyledDiv = styled.div`
+  height: 2000px;
+`;
+
 const Main = () => {
   return (
     <>
-      <h1>home화면입니다</h1>
+      <StyledDiv>home화면입니다</StyledDiv>
     </>
   );
 };

--- a/src/hooks/useNavbar.ts
+++ b/src/hooks/useNavbar.ts
@@ -1,0 +1,32 @@
+import { useState, useEffect } from 'react';
+
+/*
+미로그인시 랜딩페이지에서 스크롤 위치에 따라 하단 네비게이션바를 렌더링 여부를 return하는 hook
+ */
+const useNavbar = () => {
+  const [isLogin, setIsLogin] = useState(false); //TODO: 추후 전역 상태에서 가져옴
+  const [renderNavbar, setRenderNavbar] = useState(false);
+
+  function onScroll() {
+    if (screen.height * 0.8 < window.scrollY) {
+      setRenderNavbar(true);
+    } else {
+      setRenderNavbar(false);
+    }
+  }
+
+  useEffect(() => {
+    if (!isLogin) {
+      window.addEventListener('scroll', onScroll);
+      return () => {
+        window.removeEventListener('scroll', onScroll);
+      };
+    } else {
+      setRenderNavbar(true);
+    }
+  }, []);
+
+  return { renderNavbar };
+};
+
+export default useNavbar;

--- a/src/pages/layout/index.tsx
+++ b/src/pages/layout/index.tsx
@@ -5,16 +5,19 @@ import { useRecoilValue } from 'recoil';
 import { Outlet } from 'react-router-dom';
 import * as styles from './layout.style';
 import NavigationBar from '@/components/common/Navbar/NavigationBar';
+import useNavbar from '@/hooks/useNavbar';
 
 const MainLayout = ({ children }: PropsWithChildren<{}>) => {
   const activeNavType = useRecoilValue(userNavAtom).activeNavType;
+
+  const { renderNavbar } = useNavbar();
 
   return (
     <>
       <Header />
       {children || <Outlet />}
       <styles.NavBarWrapper>
-        <NavigationBar focusType={activeNavType} />
+        <NavigationBar focusType={activeNavType} render={renderNavbar} />
       </styles.NavBarWrapper>
     </>
   );


### PR DESCRIPTION
## Issue
#112 

- Resolves #112

## Description

- 미로그인 상태에서 랜딩페이지 스크롤을 내리면 하단 내비게이션바가 렌더링되도록 작업했습니다. 
- scrollY 높이를 확인하는 주요 로직은 `/hooks/useNavbar` 에 들어가 있습니다. 자세한 설명은 코멘트로 달도록 하겠습니다!

## Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  적절한 라벨 설정
- [x]  작업한 사람 모두를 Assign
- [x]  작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x]  `main` 브랜치의 최신 상태를 반영하고 있는지 확인

## Screenshot

![22](https://github.com/DaITssu/daitssu-client/assets/70098708/1f9f348c-20f0-4e03-8c6c-dc713aca7441)

