### PR TITLE
[#114] Calendar 과제 알림 스크린 추가

### DIFF
--- a/src/components/Calendar/AlarmSetting/AlarmSetting.stories.tsx
+++ b/src/components/Calendar/AlarmSetting/AlarmSetting.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import AlarmSetting from './AlarmSetting';
+
+const meta: Meta<typeof AlarmSetting> = {
+  title: 'Calendar/AlarmSetting',
+  component: AlarmSetting,
+};
+
+export default meta;
+type Story = StoryObj<typeof AlarmSetting>;
+
+export const AlarmSettingExample: Story = {
+  args: {
+    subjects: [
+      {
+        id: 1,
+        title: '웹프로그래밍',
+        color: '#FF7171',
+        tasks: [
+          {
+            id: 1,
+            title: 'test',
+            dueDate: '2022-10-10T09:00:00.000Z',
+            isFinished: false,
+            type: 'test',
+          },
+          {
+            id: 1,
+            title: 'test',
+            dueDate: '2022-10-10T09:00:00.000Z',
+            isFinished: false,
+            type: 'test',
+          },
+        ],
+      },
+      {
+        id: 2,
+        title: '소켓프로그래밍',
+        color: '#FF8DC4',
+        tasks: [
+          {
+            id: 1,
+            title: 'wow',
+            dueDate: '2022-10-10T09:00:00.000Z',
+            isFinished: false,
+            type: 'video',
+          },
+          {
+            id: 1,
+            title: '과제',
+            dueDate: '2022-10-10T09:00:00.000Z',
+            isFinished: false,
+            type: 'test',
+          },
+        ],
+      },
+    ],
+  },
+};

--- a/src/components/Calendar/AlarmSetting/AlarmSetting.styles.tsx
+++ b/src/components/Calendar/AlarmSetting/AlarmSetting.styles.tsx
@@ -1,0 +1,35 @@
+import { COLORS } from '@/styles/constants/colors';
+import { TEXT_STYLES } from '@/styles/constants/textStyles';
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 16px;
+
+  background: var(--white, #fff);
+`;
+
+export const LeftDiv = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+`;
+
+export const Titles = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const Label = styled.p`
+  margin: 0;
+  ${TEXT_STYLES.BodyR16}
+  color: ${COLORS.grayscale.Gray1};
+`;
+
+export const SubLabel = styled.p`
+  margin: 0;
+  ${TEXT_STYLES.CapR14}
+  color: ${COLORS.grayscale.Gray2};
+`;

--- a/src/components/Calendar/AlarmSetting/AlarmSetting.styles.tsx
+++ b/src/components/Calendar/AlarmSetting/AlarmSetting.styles.tsx
@@ -17,18 +17,13 @@ export const LeftDiv = styled.div`
   gap: 16px;
 `;
 
-export const Titles = styled.div`
-  display: flex;
-  flex-direction: column;
-`;
-
-export const Label = styled.p`
+export const Title = styled.p`
   margin: 0;
   ${TEXT_STYLES.BodyR16}
   color: ${COLORS.grayscale.Gray1};
 `;
 
-export const SubLabel = styled.p`
+export const SubTitle = styled.p`
   margin: 0;
   ${TEXT_STYLES.CapR14}
   color: ${COLORS.grayscale.Gray2};

--- a/src/components/Calendar/AlarmSetting/AlarmSetting.tsx
+++ b/src/components/Calendar/AlarmSetting/AlarmSetting.tsx
@@ -46,7 +46,7 @@ const SubjectTaskDetail = ({ task }: TaskProps) => {
   const icon = iconMapping[task.type] || video;
 
   //실제로 finish가 알림 off랑 동일한 기능이지 않음으로
-  //TODO 알림 온오프 기능 추가
+  //TODO 알림 온오프 필드값 추가 <- 실제 API 나온 이후에 작업
   const [isToggle, setIsToggle] = useState(task.isFinished);
 
   function toggle() {

--- a/src/components/Calendar/AlarmSetting/AlarmSetting.tsx
+++ b/src/components/Calendar/AlarmSetting/AlarmSetting.tsx
@@ -19,7 +19,7 @@ const AlarmSetting = (props: AlarmProps) => {
     <>
       {props.subjects.map((subject, index) => (
         <div key={index}>
-          <SubjectTitle subject={subject}></SubjectTitle>
+          <SubjectTitle subject={subject} />
           {subject.tasks.map((task, index) => (
             <SubjectTaskDetail task={task} key={index} />
           ))}
@@ -58,10 +58,10 @@ const SubjectTaskDetail = ({ task }: TaskProps) => {
     <styles.Container>
       <styles.LeftDiv>
         <Image priority src={icon} alt={icon} width={24} height={24} />
-        <styles.Titles>
-          <styles.Label>{task.title}</styles.Label>
-          <styles.SubLabel>{time + '까지'}</styles.SubLabel>
-        </styles.Titles>
+        <div style={{ flexDirection: 'column' }}>
+          <styles.Title>{task.title}</styles.Title>
+          <styles.SubTitle>{time + '까지'}</styles.SubTitle>
+        </div>
       </styles.LeftDiv>
       <ToggleButton isToggle={isToggle} onToggle={toggle} />
     </styles.Container>

--- a/src/components/Calendar/AlarmSetting/AlarmSetting.tsx
+++ b/src/components/Calendar/AlarmSetting/AlarmSetting.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import * as styles from './AlarmSetting.styles';
+import ToggleButton from '@/components/common/Button/ToggleButton';
+import video from '@icons/icon/LectureAssignment/Video.svg';
+import comment from '@icons/icon/LectureAssignment/Comment.svg';
+import assignment from '@icons/icon/LectureAssignment/Assignment.svg';
+import Image from 'next/image';
+import SubjectTitle from '../SubjectTitle';
+import { SubjectDTO } from '@/types/Subject';
+
+import { TaskProps } from '@/types/Task';
+
+interface AlarmProps {
+  subjects: SubjectDTO[];
+}
+
+const AlarmSetting = (props: AlarmProps) => {
+  return (
+    <>
+      {props.subjects.map((subject, index) => (
+        <div key={index}>
+          <SubjectTitle subject={subject}></SubjectTitle>
+          {subject.tasks.map((task, index) => (
+            <SubjectTaskDetail task={task} key={index} />
+          ))}
+        </div>
+      ))}
+    </>
+  );
+};
+
+const SubjectTaskDetail = ({ task }: TaskProps) => {
+  const date = new Date(task.dueDate);
+
+  const time = date.toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+
+  const iconMapping: { [key: string]: any } = {
+    video: video,
+    comment: comment,
+    assignment: assignment,
+  };
+  const icon = iconMapping[task.type] || video;
+
+  //실제로 finish가 알림 off랑 동일한 기능이지 않음으로
+  //TODO 알림 온오프 기능 추가
+  const [isToggle, setIsToggle] = useState(task.isFinished);
+
+  function toggle() {
+    setIsToggle(!isToggle);
+    // TODO 온오프 API 연결
+  }
+
+  return (
+    <styles.Container>
+      <styles.LeftDiv>
+        <Image priority src={icon} alt={icon} width={24} height={24} />
+        <styles.Titles>
+          <styles.Label>{task.title}</styles.Label>
+          <styles.SubLabel>{time + '까지'}</styles.SubLabel>
+        </styles.Titles>
+      </styles.LeftDiv>
+      <ToggleButton isToggle={isToggle} onToggle={toggle} />
+    </styles.Container>
+  );
+};
+
+export default AlarmSetting;

--- a/src/components/Calendar/AlarmSetting/index.ts
+++ b/src/components/Calendar/AlarmSetting/index.ts
@@ -1,0 +1,3 @@
+import AlarmSetting from './AlarmSetting';
+
+export default AlarmSetting;

--- a/src/components/Calendar/Calendar/Calendar.stories.tsx
+++ b/src/components/Calendar/Calendar/Calendar.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import Calendar from './Calendar';
 
 const meta: Meta<typeof Calendar> = {
-  title: 'Calendar',
+  title: 'Calendar/Calendar',
   component: Calendar,
 };
 

--- a/src/components/Calendar/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar/Calendar.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import DayBlock from '../DayBlock/DayBlock';
-import WeekBlock from '../WeekBlock/WeekBlock';
+import WeekBlock from './WeekBlock/WeekBlock';
 import MonthControlButton from '../MonthControlButton/MonthControlButton';
 import * as styles from './Calendar.styles';
 

--- a/src/components/Calendar/Calendar/WeekBlock/WeekBlock.tsx
+++ b/src/components/Calendar/Calendar/WeekBlock/WeekBlock.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Container } from '../Calendar/Calendar.styles';
-import { DayBlockN, DayBlockBox } from '../DayBlock/DayBlock.styles';
+import { Container } from '../Calendar.styles';
+import { DayBlockN, DayBlockBox } from '../../DayBlock/DayBlock.styles';
 
 const WeekBlock = () => {
   const dayList: string[] = ['MON', 'TUE', 'WED', 'THU', 'FRI'];

--- a/src/components/Calendar/CalendarScreen/CalendarButton/CalendarButton.styles.tsx
+++ b/src/components/Calendar/CalendarScreen/CalendarButton/CalendarButton.styles.tsx
@@ -3,7 +3,6 @@ import { TEXT_STYLES } from '@/styles/constants/textStyles';
 import styled from '@emotion/styled';
 
 export const CalendarButtonContainer = styled.div`
-  width: 100%;
   height: 30px;
   border-radius: 30px;
   display: flex;

--- a/src/components/Calendar/CalendarScreen/CalendarScreen.stories.tsx
+++ b/src/components/Calendar/CalendarScreen/CalendarScreen.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import CalendarScreen from './CalendarScreen';
 
 const meta: Meta<typeof CalendarScreen> = {
-  title: 'Calendar',
+  title: 'Calendar/CalendarScreen',
   component: CalendarScreen,
 };
 

--- a/src/components/Calendar/CalendarScreen/CalendarScreen.tsx
+++ b/src/components/Calendar/CalendarScreen/CalendarScreen.tsx
@@ -9,8 +9,10 @@ import Modal from '@/components/common/Modal';
 import EditEventModal from '../EditEventModal';
 import CalendarIcon from '@icons/icon/Icon24/CalenderUpdate.svg';
 import Image from 'next/image';
+import { useRouter } from 'next/router';
 
 const CalendarScreen = () => {
+  const router = useRouter();
   const { open, PopUp, close } = useModal();
 
   const [year, setYear] = useState<number>(2023);
@@ -27,6 +29,11 @@ const CalendarScreen = () => {
   function onMonthChange(year: number, month: number) {
     setYear(year);
     setMonth(month);
+  }
+
+  function onEditAlarmClick() {
+    //TODO 알림 화면에서 보여줄 데이터 전달
+    router.push('/calendar/alarm');
   }
 
   // now
@@ -78,7 +85,7 @@ const CalendarScreen = () => {
                 alt="Calendar Update"
               />
             </div>
-            <CalendarButton text={'알림설정'} onClick={open} />
+            <CalendarButton text={'알림설정'} onClick={onEditAlarmClick} />
             <CalendarButton text={'추가'} onClick={open} />
           </styles.row>
         </styles.rowSpaceBetween>

--- a/src/components/Calendar/EditEventModal/EditEventModal.stories.tsx
+++ b/src/components/Calendar/EditEventModal/EditEventModal.stories.tsx
@@ -6,7 +6,7 @@ import Modal from '@/components/common/Modal';
 import useModal from '@/components/common/Modal/useModal';
 
 const meta: Meta<typeof EditEventModal> = {
-  title: 'Calendar',
+  title: 'Calendar/EditEventModal',
   component: EditEventModal,
 };
 

--- a/src/components/calendar/Subject/Subject.stories.tsx
+++ b/src/components/calendar/Subject/Subject.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import Subject from './Subject';
 
 const meta: Meta<typeof Subject> = {
-  title: 'Calendar',
+  title: 'Calendar/Subject',
   component: Subject,
 };
 

--- a/src/components/calendar/SubjectContents/SubjectContents.stories.tsx
+++ b/src/components/calendar/SubjectContents/SubjectContents.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import SubjectContents from './SubjectContents';
 
 const meta: Meta<typeof SubjectContents> = {
-  title: 'Calendar',
+  title: 'Calendar/SubjectContents',
   component: SubjectContents,
 };
 

--- a/src/components/calendar/SubjectContents/SubjectContents.tsx
+++ b/src/components/calendar/SubjectContents/SubjectContents.tsx
@@ -3,10 +3,10 @@ import * as styles from './SubjectContents.style';
 import video from '@icons/icon/LectureAssignment/Video.svg';
 import comment from '@icons/icon/LectureAssignment/Comment.svg';
 import assignment from '@icons/icon/LectureAssignment/Assignment.svg';
-import { TaskDTO, TaskProps } from '@/types/Task';
+import { TaskProps } from '@/types/Task';
 import Status from '../../common/Status/index';
-import { TEXT_STYLES } from '../../../styles/constants/textStyles';
-import { COLORS } from '../../../styles/constants/colors';
+import { COLORS } from '@/styles/constants/colors';
+import { TEXT_STYLES } from '@/styles/constants/textStyles';
 
 const SubjectContents = ({ task }: TaskProps) => {
   const date = new Date(task.dueDate);

--- a/src/components/calendar/SubjectContents/SubjectContents.tsx
+++ b/src/components/calendar/SubjectContents/SubjectContents.tsx
@@ -18,18 +18,23 @@ const SubjectContents = ({ task }: TaskProps) => {
   });
 
   // 1 : 완료, 2 : 시간초과, 0 : 미완료
+  enum StatusNumber {
+    FINISHED = 1,
+    OVERDUE = 2,
+    UNFINISHED = 0,
+  }
   const statusNumber = task.isFinished
-    ? 1
+    ? StatusNumber.FINISHED
     : Date.now() > date.getTime()
-    ? 2
-    : 0;
+    ? StatusNumber.OVERDUE
+    : StatusNumber.UNFINISHED;
 
-  const statusMapping = {
-    0: '미완료',
-    1: '완료',
-    2: '시간초과',
-  };
-  const statusLabel = statusMapping[statusNumber] || '미완료';
+  const statusLabel =
+    statusNumber === StatusNumber.FINISHED
+      ? '완료'
+      : statusNumber === StatusNumber.OVERDUE
+      ? '시간초과'
+      : '미완료';
 
   const iconMapping: { [key: string]: any } = {
     video: video,

--- a/src/components/calendar/SubjectContents/SubjectContents.tsx
+++ b/src/components/calendar/SubjectContents/SubjectContents.tsx
@@ -8,11 +8,6 @@ import Status from '../../common/Status/index';
 import { TEXT_STYLES } from '../../../styles/constants/textStyles';
 import { COLORS } from '../../../styles/constants/colors';
 
-const getTaskStatus = (dueDate: Date, task: TaskDTO) => {
-  if (task.isFinished) return 1;
-  return Date.now() > dueDate.getTime() ? 2 : 0;
-};
-
 const SubjectContents = ({ task }: TaskProps) => {
   const date = new Date(task.dueDate);
 
@@ -22,7 +17,13 @@ const SubjectContents = ({ task }: TaskProps) => {
     hour12: false,
   });
 
-  const statusNumber = getTaskStatus(date, task);
+  // 1 : 완료, 2 : 시간초과, 0 : 미완료
+  const statusNumber = task.isFinished
+    ? 1
+    : Date.now() > date.getTime()
+    ? 2
+    : 0;
+
   const statusMapping = {
     0: '미완료',
     1: '완료',

--- a/src/components/calendar/SubjectList/SubjectList.stories.tsx
+++ b/src/components/calendar/SubjectList/SubjectList.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import SubjectList from './SubjectList';
 
 const meta: Meta<typeof SubjectList> = {
-  title: 'Calendar',
+  title: 'Calendar/SubjectList',
   component: SubjectList,
 };
 

--- a/src/components/calendar/SubjectTitle/SubjectTitle.stories.tsx
+++ b/src/components/calendar/SubjectTitle/SubjectTitle.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import SubjectTitle from './SubjectTitle';
 
 const meta: Meta<typeof SubjectTitle> = {
-  title: 'Calendar',
+  title: 'Calendar/SubjectTitle',
   component: SubjectTitle,
 };
 

--- a/src/components/common/Status/Status.styles.ts
+++ b/src/components/common/Status/Status.styles.ts
@@ -1,6 +1,6 @@
-import { COLORS } from '../../../styles/constants/colors';
 import styled from '@emotion/styled';
-import { TEXT_STYLES } from '../../../styles/constants/textStyles';
+import { TEXT_STYLES } from '@/styles/constants/textStyles';
+import { COLORS } from '@/styles/constants/colors';
 
 // 가독성을 위해 스타일 파일은 별도로 둡니다.
 

--- a/src/pages/calendar/alarm/index.page.tsx
+++ b/src/pages/calendar/alarm/index.page.tsx
@@ -1,5 +1,6 @@
 import AlarmSetting from '@/components/Calendar/AlarmSetting';
 import Header from '@/components/common/Header/Header';
+import { useEffect } from 'react';
 
 export default function AlarmScreen() {
   const example = [
@@ -46,6 +47,10 @@ export default function AlarmScreen() {
       ],
     },
   ];
+
+  useEffect(() => {
+    //TODO 과제 알림 데이터 불러오는 API 연결 함수 작성
+  }, []);
 
   return (
     <>

--- a/src/pages/calendar/alarm/index.page.tsx
+++ b/src/pages/calendar/alarm/index.page.tsx
@@ -1,0 +1,56 @@
+import AlarmSetting from '@/components/Calendar/AlarmSetting';
+import Header from '@/components/common/Header/Header';
+
+export default function AlarmScreen() {
+  const example = [
+    {
+      id: 1,
+      title: '웹프로그래밍',
+      color: '#FF7171',
+      tasks: [
+        {
+          id: 1,
+          title: 'test',
+          dueDate: '2022-10-10T09:00:00.000Z',
+          isFinished: false,
+          type: 'test',
+        },
+        {
+          id: 1,
+          title: 'test',
+          dueDate: '2022-10-10T09:00:00.000Z',
+          isFinished: false,
+          type: 'test',
+        },
+      ],
+    },
+    {
+      id: 2,
+      title: '소켓프로그래밍',
+      color: '#FF8DC4',
+      tasks: [
+        {
+          id: 1,
+          title: 'wow',
+          dueDate: '2022-10-10T09:00:00.000Z',
+          isFinished: false,
+          type: 'video',
+        },
+        {
+          id: 1,
+          title: '과제',
+          dueDate: '2022-10-10T09:00:00.000Z',
+          isFinished: false,
+          type: 'test',
+        },
+      ],
+    },
+  ];
+
+  return (
+    <>
+      <Header />
+      <AlarmSetting subjects={example} />
+    </>
+  );
+}


### PR DESCRIPTION
## Issue

- Resolves #114 

## Description

- 캘린더 스크린에서 과제 알림 온/오프 기능이 누락된 것을 확인하고 추가하였습니다.
- 기존 캘린더 컴포넌트에서 코드를 수정할 부분을 일부 수정하였습니다.

## Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  적절한 라벨 설정
- [x]  작업한 사람 모두를 Assign
- [x]  작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x]  `main` 브랜치의 최신 상태를 반영하고 있는지 확인

## Screenshot

![스크린샷 2023-10-02 오후 2 35 49](https://github.com/DaITssu/daitssu-client/assets/96258104/c42e1dd6-3134-4468-97e0-2853edae8acb)
![스크린샷 2023-10-02 오후 2 37 27](https://github.com/DaITssu/daitssu-client/assets/96258104/2341f7c8-b2a4-422b-a7c4-6f949db202f1)
