### PR TITLE
[#119] NavigationBar props 관련 에러 수정

### DIFF
--- a/src/components/common/Navbar/NavigationBar.tsx
+++ b/src/components/common/Navbar/NavigationBar.tsx
@@ -4,10 +4,10 @@ import NavItem from './NavItem';
 
 interface NavigationBarProps {
   focusType: keyof typeof NAV_LIST;
-  render: boolean;
+  render?: boolean;
 }
 
-const NavigationBar = ({ focusType, render }: NavigationBarProps) => {
+const NavigationBar = ({ focusType, render = true }: NavigationBarProps) => {
   return (
     <>
       <styles.Navigaton render={render}>


### PR DESCRIPTION
## Issue

- Resolves #119 

## Description

- Navigationbar에 추가한 `render` props를 필수로 지정해놓아서 기존에 사용하던 코드에서 에러나는 부분들이 있더라고요..!(머쓱)
   필수 아닌걸로 바꾸고 기본값 지정해주었습니다!

## Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  적절한 라벨 설정
- [x]  작업한 사람 모두를 Assign
- [x]  작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x]  `main` 브랜치의 최신 상태를 반영하고 있는지 확인

## Screenshot

