### PR TITLE
[#121] 모바일 뷰 관련 작업

### DIFF
--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -1,5 +1,6 @@
 import '@/styles/globals.css';
 import type { AppProps } from 'next/app';
+import Head from 'next/head';
 import {
   QueryClient,
   QueryClientProvider,
@@ -15,6 +16,12 @@ export default function App({ Component, pageProps }: AppProps) {
     <QueryClientProvider client={queryClient}>
       <RecoilRoot>
         <Hydrate state={pageProps.dehydratedState}>
+          <Head>
+            <meta
+              name="viewport"
+              content="width=device-width, initial-scale=1.0, user-scalable=no, maximum-scale=1.0"
+            />
+          </Head>
           <Component {...pageProps} />
         </Hydrate>
       </RecoilRoot>

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -1,5 +1,5 @@
 import MainLayout from './layout';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useSetRecoilState } from 'recoil';
 import { userNavAtom, IUserNavAtom } from '@/states/userNavAtom';
 import { NAV_LIST } from '@/components/common/Navbar/Navigation';
@@ -15,6 +15,17 @@ const MainPage = () => {
 
   //TODO: 추후 전역 상태로 관리
   const [isLogin, setIsLogin] = useState<boolean>(false);
+
+  //mobile height size 설정
+  useEffect(() => {
+    const vh = window.innerHeight * 0.01;
+    document.documentElement.style.setProperty('--vh', `${vh}px`);
+
+    window.addEventListener('resize', () => {
+      const vh = window.innerHeight * 0.01;
+      document.documentElement.style.setProperty('--vh', `${vh}px`);
+    });
+  }, []);
 
   if (isLogin) {
     return (


### PR DESCRIPTION
## Issue

- Resolves #121 

## Description

1. 모바일 환경에서 input 포커스시 화면 확대 방지 태그 추가
    - [공식 문서](https://nextjs.org/docs/messages/no-document-viewport-meta)에 따라서 app.page.tsx에 viewport meta tag를 추가했습니다! 
2. 모바일 환경에서 height size 조절
    - 모바일 브라우저에서 100vh 사용시 화면 전체를 볼 수 없는 이슈가 생기기도 하는데 이를 위해서 height를 변경하고 있습니다. 
    - [참고링크](https://triplexblog.kr/116), [참고링크](https://velog.io/@eunddodi/React-%EB%AA%A8%EB%B0%94%EC%9D%BC-%EC%9B%B9-%EC%95%B1-100vh-%EC%8B%A4%EC%A0%9C-%ED%99%94%EB%A9%B4-%ED%81%AC%EA%B8%B0%EB%A1%9C-%EB%A7%9E%EC%B6%94%EA%B8%B0)
    
## Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  적절한 라벨 설정
- [x]  작업한 사람 모두를 Assign
- [x]  작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x]  `main` 브랜치의 최신 상태를 반영하고 있는지 확인

## Screenshot

