### PR TITLE
[#159] Header 관련 로직 추가

### DIFF
--- a/src/components/Home/NoticeFunSystem/NoticeFunSystem.styles.tsx
+++ b/src/components/Home/NoticeFunSystem/NoticeFunSystem.styles.tsx
@@ -1,71 +1,70 @@
 import styled from '@emotion/styled';
 import { TEXT_STYLES } from '@/styles/constants/textStyles';
 export const SummaryBox = styled.div`
-  width : 100%;
-  heigth : 264px;
-  padding : 16px 24px;
-  background: #FFFFFF;
+  width: 100%;
+  height: 264px;
+  padding: 16px 24px;
+  background: #ffffff;
 `;
 export const TopBox = styled.div`
-  display : flex; 
+  display: flex;
   justify-content: space-between;
 `;
 
 export const Title = styled.div`
   ${TEXT_STYLES.HeadM20};
-  left : 0px;
- 
+  left: 0px;
 `;
 export const MoreButton = styled.div`
   ${TEXT_STYLES.CapR14};
-  color : #6E6E6E;
-  margin-top : 4px;
-  display : flex;
-  align-items : center;
+  color: #6e6e6e;
+  margin-top: 4px;
+  display: flex;
+  align-items: center;
 `;
 
 export const TextBox = styled.div`
   box-sizing: border-box;
   position: relative;
   width: 100%;
-  height : 170px;
-  margin-top : 16px;
-  background: #FFFFFF;
-  border: 1px solid #D9D9D9;
+  height: 170px;
+  margin-top: 16px;
+  background: #ffffff;
+  border: 1px solid #d9d9d9;
   box-shadow: 4px 4px 10px rgba(0, 0, 0, 0.05);
   border-radius: 15px;
 `;
 
-export const Line = styled.div<{top : string}>`
-  width : 100%;
-  height : 1px;
-  top : ${(props)=> props.top};
-  position : absolute;
-  background-color : #D9D9D9;
+export const Line = styled.div<{ top: string }>`
+  width: 100%;
+  height: 1px;
+  top: ${(props) => props.top};
+  position: absolute;
+  background-color: #d9d9d9;
 `;
 
-export const TextLine = styled.div<{top : string}>`
-  display : flex; 
-  width : 100%;
-  position : absolute;
+export const TextLine = styled.div<{ top: string }>`
+  display: flex;
+  width: 100%;
+  position: absolute;
   // margin : 0px 12px;
-  top : ${(props)=> props.top};
-  box-sizing : border-box;
+  top: ${(props) => props.top};
+  box-sizing: border-box;
 `;
 
 export const TextSummary = styled.div`
   ${TEXT_STYLES.BodyM16};
-  white-space : nowrap;
-  overflow : hidden;
-  display : auto;
-  text-overflow : ellipsis;
-  padding-right : 50px;
+  white-space: nowrap;
+  overflow: hidden;
+  display: auto;
+  text-overflow: ellipsis;
+  padding-right: 50px;
   padding-left: 12px;
 `;
 
 export const Date = styled.div`
   ${TEXT_STYLES.CapR14};
-  color : #6E6E6E;
-  position : absolute;
-  right : 12px;
+  color: #6e6e6e;
+  position: absolute;
+  right: 12px;
 `;

--- a/src/components/Home/NoticeFunSystem/NoticeFunSystem.tsx
+++ b/src/components/Home/NoticeFunSystem/NoticeFunSystem.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import * as styles from './NoticeFunSystem.styles';
 import RightArrow from '@icons/icon/Arrow/RightSmallArrow.svg';
 import Image from 'next/image';
+import { useRouter } from 'next/router';
 
 export interface SummaryText {
   id: number;
@@ -17,11 +18,21 @@ export interface NoticeFunSystemProps {
 }
 
 const NoticeFunSystem = (props: NoticeFunSystemProps) => {
+  const router = useRouter();
+
+  function handleOnClickMore() {
+    if (props.title === '공지사항') {
+      router.push('/notice');
+    } else {
+      router.push('/funsystem');
+    }
+  }
+
   return (
     <styles.SummaryBox>
       <styles.TopBox>
         <styles.Title>{props.title}</styles.Title>
-        <styles.MoreButton>
+        <styles.MoreButton onClick={handleOnClickMore}>
           더보기
           <Image src={RightArrow} alt="right arrow" />
         </styles.MoreButton>

--- a/src/components/Home/NoticeFunSystemTab/LineSearchBar/LineSearchBar.styles.ts
+++ b/src/components/Home/NoticeFunSystemTab/LineSearchBar/LineSearchBar.styles.ts
@@ -1,15 +1,15 @@
 import styled from '@emotion/styled';
 import Image from 'next/image';
 import { TEXT_STYLES } from '@/styles/constants/textStyles';
-import {COLORS} from '@/styles/constants/colors';
+import { COLORS } from '@/styles/constants/colors';
 
 export const SearchBarBox = styled.div`
-  width : 100%;
-  height :56px;
-  padding-left : 16px;
-  padding-right : 16px;
-  padding-bottom : 8px; 
-  box-sizing : border-box;
+  width: 100%;
+  height: 56px;
+  padding-left: 16px;
+  padding-right: 16px;
+  padding-bottom: 8px;
+  box-sizing: border-box;
   background: ${COLORS.grayscale.white};
 `;
 
@@ -26,6 +26,8 @@ export const Input = styled.input`
   border: none;
   outline: none;
   ${TEXT_STYLES.BodyM16};
+  background-color: white;
+  color: ${COLORS.grayscale.Black};
 `;
 
 export const GlassImage = styled(Image)`
@@ -33,10 +35,10 @@ export const GlassImage = styled(Image)`
 `;
 export const Circle = styled.div`
   margin-right: 15px;
-  width : 18px;
-  height : 18px;
-  border-radius : 50%;
-  background-color : ${COLORS.grayscale.Gray3};
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background-color: ${COLORS.grayscale.Gray3};
 `;
 export const CancelImage = styled(Image)`
   filter: brightness(0) invert(1);

--- a/src/components/Home/NoticeFunSystemTab/LineSearchBar/LineSearchBar.tsx
+++ b/src/components/Home/NoticeFunSystemTab/LineSearchBar/LineSearchBar.tsx
@@ -3,7 +3,11 @@ import * as styles from './LineSearchBar.styles';
 import searchicon from '@icons/icon/Search/BlueSearch.svg';
 import cancelicon from '@icons/icon/SubscribeList/Cancel.svg';
 
-const LineSearchBar = ({onSearch}:{onSearch : (searchText:string)=>void}) => {
+const LineSearchBar = ({
+  onSearch,
+}: {
+  onSearch: (searchText: string) => void;
+}) => {
   const [searchText, setSearchText] = useState('');
 
   const handleOnKeyPress = (e: KeyboardEvent<HTMLInputElement>) => {
@@ -15,7 +19,7 @@ const LineSearchBar = ({onSearch}:{onSearch : (searchText:string)=>void}) => {
   const handleClearSearch = () => {
     setSearchText('');
   };
-  const handleSearch = () =>{
+  const handleSearch = () => {
     onSearch(searchText);
   };
 
@@ -30,18 +34,23 @@ const LineSearchBar = ({onSearch}:{onSearch : (searchText:string)=>void}) => {
           onChange={(e) => setSearchText(e.target.value)}
         />
         <styles.Circle onClick={handleClearSearch}>
-          <styles.CancelImage src={cancelicon} width={18} height={18} alt={''} />
+          <styles.CancelImage
+            src={cancelicon}
+            width={18}
+            height={18}
+            alt={''}
+          />
         </styles.Circle>
-        
-        <styles.GlassImage 
+
+        <styles.GlassImage
           src={searchicon}
-          width={24} 
-          height={24} 
-          alt={''} 
-          onClick={handleSearch}/>
+          width={24}
+          height={24}
+          alt={''}
+          onClick={handleSearch}
+        />
       </styles.SearchBarStyles>
     </styles.SearchBarBox>
-    
   );
 };
 

--- a/src/components/Home/NoticeFunSystemTab/NoticeFunSystemTab.tsx
+++ b/src/components/Home/NoticeFunSystemTab/NoticeFunSystemTab.tsx
@@ -5,20 +5,17 @@ import LineSearchBar from './LineSearchBar/LineSearchBar';
 import CommunityList from '@/components/community/list/CommunityList';
 import FunSystemList from '@/components/notice/FunSystemList';
 
-
 const NoticeFunSystemTab = () => {
-  
-  
   const [index, setIndex] = useState(0);
-  const [search, setSearch] = useState("");
+  const [search, setSearch] = useState('');
 
-  useEffect(()=>{
+  useEffect(() => {
     window.location.reload;
   }, [index, search]);
 
-  const handleSearch = (searchText : string) =>{
+  const handleSearch = (searchText: string) => {
     setSearch(searchText);
-  }
+  };
 
   const selectMenuHandler = (n: number) => {
     setIndex(n);
@@ -26,27 +23,33 @@ const NoticeFunSystemTab = () => {
 
   return (
     <>
-      <LineSearchBar onSearch = {handleSearch}/>
-      {search && <styles.TabContainer>
-        <styles.TabBox>
-          {["공지사항", "펀시스템","커뮤니티"].map((element, idx) => (
-            <styles.TabFontBox
-              key={idx}
-              isSelected={idx === index}
-              onClick={() => selectMenuHandler(idx)}>
-              {element}
-            </styles.TabFontBox>
-          ))}
-        </styles.TabBox>
-        {index === 0 ? (
-          <NoticeList key={search} search = {search} category = "ALL"/>
-        ) : index === 1 ?(
-          <FunSystemList key={search} search = {search} category = "ALL"/>
-        ) : (
-          <CommunityList key={search} isButtonVisible = {false} search = {search}/>
-        )}
-      </styles.TabContainer>}
-      
+      <LineSearchBar onSearch={handleSearch} />
+      {search && (
+        <styles.TabContainer>
+          <styles.TabBox>
+            {['공지사항', '펀시스템', '커뮤니티'].map((element, idx) => (
+              <styles.TabFontBox
+                key={idx}
+                isSelected={idx === index}
+                onClick={() => selectMenuHandler(idx)}
+              >
+                {element}
+              </styles.TabFontBox>
+            ))}
+          </styles.TabBox>
+          {index === 0 ? (
+            <NoticeList key={search} search={search} category="ALL" />
+          ) : index === 1 ? (
+            <FunSystemList key={search} search={search} category="ALL" />
+          ) : (
+            <CommunityList
+              key={search}
+              isButtonVisible={false}
+              search={search}
+            />
+          )}
+        </styles.TabContainer>
+      )}
     </>
   );
 };

--- a/src/components/Home/PopularPosts/PopularPosts.styles.ts
+++ b/src/components/Home/PopularPosts/PopularPosts.styles.ts
@@ -7,7 +7,7 @@ export const Container = styled.div`
   display: flex;
   background-color: ${COLORS.grayscale.Gray5};
   flex-direction: column;
-  padding: 20px;
+  padding: 16px 24px;
 `;
 
 export const RowSpacer = styled.div`

--- a/src/components/Home/PopularPosts/PopularPosts.tsx
+++ b/src/components/Home/PopularPosts/PopularPosts.tsx
@@ -15,11 +15,15 @@ export interface PostDetailProps {
 }
 
 const PopularPosts = ({ posts }: { posts: PostDetailProps[] }) => {
+  const router = useRouter();
+  const handleOnClickMore = () => {
+    router.push('/community');
+  };
   return (
     <styles.Container>
       <styles.RowSpacer>
         <styles.Title>인기 게시글</styles.Title>
-        <styles.MoreButton>
+        <styles.MoreButton onClick={handleOnClickMore}>
           더보기{' '}
           <Image
             src={RightSmallArrow}

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -2,29 +2,63 @@ import * as styles from './Header.style';
 import SearchIcon from '@icons/icon/header/search.svg';
 import AlarmIcon from '@icons/icon/header/alarm.svg';
 import Image from 'next/image';
-import { useState } from 'react';
-import LineSearchBar from '@/components/Home/NoticeFunSystemTab/LineSearchBar/LineSearchBar';
+import { useEffect, useState } from 'react';
 import NoticeFunSystemTab from '@/components/Home/NoticeFunSystemTab/NoticeFunSystemTab';
+import { useRouter } from 'next/router';
+
 const Header = () => {
+  const router = useRouter();
+  const [isHeaderVisible, setIsHeaderVisible] = useState(true);
   const [isSearchVisible, setIsSearchVisible] = useState(false);
-  const handleSearchIconClick=()=>{
-    setIsSearchVisible((prev)=> !prev);
-  }
+
+  const handleSearchIconClick = () => {
+    setIsSearchVisible((prev) => !prev);
+  };
+
+  const handleLogoClick = () => {
+    router.push('/');
+  };
+
+  const handleAlarmIconClick = () => {
+    router.push('/alarm');
+  };
+
+  useEffect(() => {
+    const path = router.pathname;
+    if (['/login', '/landing'].includes(path)) {
+      setIsHeaderVisible(false);
+    } else {
+      setIsHeaderVisible(true);
+    }
+  }, [router.pathname]);
 
   return (
     <>
-      <styles.Conatiner>
-        <styles.LogoText>DAITSSU</styles.LogoText>
-        <styles.IconContainer>
-          <Image  src={SearchIcon} 
-                  height={24} 
-                  width={24} 
-                  alt="search" 
-                  onClick={handleSearchIconClick} />
-          <Image src={AlarmIcon} height={24} width={24} alt="alarm" />
-        </styles.IconContainer>
-      </styles.Conatiner>
-      {isSearchVisible && <NoticeFunSystemTab/>}
+      {isHeaderVisible && (
+        <>
+          <styles.Conatiner>
+            <styles.LogoText onClick={handleLogoClick}>DAITSSU</styles.LogoText>
+            <styles.IconContainer>
+              <Image
+                src={SearchIcon}
+                height={24}
+                width={24}
+                alt="search"
+                onClick={handleSearchIconClick}
+              />
+              {/* 알림 기능 완성까지 보류 */}
+              {/* <Image
+                src={AlarmIcon}
+                height={24}
+                width={24}
+                alt="alarm"
+                onClick={handleAlarmIconClick}
+              /> */}
+            </styles.IconContainer>
+          </styles.Conatiner>
+          {isSearchVisible && <NoticeFunSystemTab />}
+        </>
+      )}
     </>
   );
 };

--- a/src/components/common/Navbar/Navigation.ts
+++ b/src/components/common/Navbar/Navigation.ts
@@ -8,7 +8,7 @@ export const NAV_LIST = {
 
 export const NAV_URL_LIST = {
   [NAV_LIST.HOME]: '/',
-  [NAV_LIST.ANNOUNCEMENT]: '/announcement',
+  [NAV_LIST.ANNOUNCEMENT]: '/notice',
   [NAV_LIST.COMMUNITY]: '/community',
   [NAV_LIST.CALENDAR]: '/calendar',
   [NAV_LIST.MY_PAGE]: '/myPage',

--- a/src/components/landing/index.tsx
+++ b/src/components/landing/index.tsx
@@ -18,7 +18,6 @@ const Landing = () => {
       />
       <LandingLogo />
       <AuthContent />
-      <ScrollDownBtn />
     </styles.LandingLayout>
   );
 };

--- a/src/components/main/index.tsx
+++ b/src/components/main/index.tsx
@@ -19,15 +19,18 @@ const Main = () => {
     const funSystemResponse = getFunsystem();
 
     popularArticleResponse.then((data) => {
-      setPosts(data.data);
+      const result: PostDetailProps[] = data.data;
+      setPosts(result.slice(0, 3));
     });
 
     noticeResponse.then((data) => {
-      setNoticeList(data.data.content);
+      const result: SummaryText[] = data.data.content;
+      setNoticeList(result.slice(0, 3));
     });
 
     funSystemResponse.then((data) => {
-      setFunSystemList(data.data.content);
+      const result: SummaryText[] = data.data.content;
+      setFunSystemList(result.slice(0, 3));
     });
   }, []);
 

--- a/src/hooks/useNavbar.ts
+++ b/src/hooks/useNavbar.ts
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 미로그인시 랜딩페이지에서 스크롤 위치에 따라 하단 네비게이션바를 렌더링 여부를 return하는 hook
  */
 const useNavbar = () => {
-  const [isLogin, setIsLogin] = useState(false); //TODO: 추후 전역 상태에서 가져옴
+  const [isLogin, setIsLogin] = useState(true); //TODO: 추후 전역 상태에서 가져옴
   const [renderNavbar, setRenderNavbar] = useState(false);
 
   function onScroll() {

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -5,16 +5,12 @@ import { userNavAtom, IUserNavAtom } from '@/states/userNavAtom';
 import { NAV_LIST } from '@/components/common/Navbar/Navigation';
 import '../styles/Home.module.css';
 import Main from '@/components/main';
-import Landing from '@/components/landing';
 
 const MainPage = () => {
   const setNavAtom = useSetRecoilState(userNavAtom);
   const navState: IUserNavAtom = {
     activeNavType: NAV_LIST.HOME,
   };
-
-  //TODO: 추후 전역 상태로 관리
-  const [isLogin, setIsLogin] = useState<boolean>(false);
 
   //mobile height size 설정
   useEffect(() => {
@@ -27,21 +23,12 @@ const MainPage = () => {
     });
   }, []);
 
-  if (isLogin) {
-    return (
+  return (
+    <div>
       <MainLayout>
         <Main />
       </MainLayout>
-    );
-  } else {
-    return (
-      <>
-        <Landing />
-        <MainLayout>
-          <Main />
-        </MainLayout>
-      </>
-    );
-  }
+    </div>
+  );
 };
 export default MainPage;

--- a/src/pages/landing/index.page.tsx
+++ b/src/pages/landing/index.page.tsx
@@ -1,0 +1,9 @@
+import Landing from '@/components/landing';
+
+export default function Home() {
+  return (
+    <>
+      <Landing />
+    </>
+  );
+}

--- a/src/pages/layout/index.tsx
+++ b/src/pages/layout/index.tsx
@@ -1,4 +1,3 @@
-import Header from '@/components/common/Header/Header';
 import { userNavAtom } from '@/states/userNavAtom';
 import { PropsWithChildren } from 'react';
 import { useRecoilValue } from 'recoil';

--- a/src/pages/login/index.page.tsx
+++ b/src/pages/login/index.page.tsx
@@ -1,5 +1,11 @@
+import UtilityHeader from '@/components/common/Header/UtilityHeader';
 import LoginLayout from '@/components/login/LoginLayout/LoginLayout';
 
 export default function Login() {
-  return <LoginLayout />;
+  return (
+    <>
+      <UtilityHeader child="" />
+      <LoginLayout />
+    </>
+  );
 }


### PR DESCRIPTION
## Issue

- Resolves #159 

## Description

### 얘기할 것
- 메인화면이 반쯤 잘려서 보여요... 이거 어떻게 하죠??

### 수정사항
- Header의 로고 터치 시, `/`로 이동
- 알림 터치 시, 현재 관련 뷰가 구현 안되어 있어서 주석 처리
- nav에서 notice로 연결되는 라우팅이 기존에 `/announce`로 되어 있던 부분 수정
- 조건에 따라서 헤더 결정 추가

## Check List

- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] PR에 해당되는 Issue를 연결 완료
- [x] 적절한 라벨 설정
- [x] 작업한 사람 모두를 Assign
- [x] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인

## Screenshot
<img width="1840" alt="스크린샷 2023-12-28 오후 10 54 26" src="https://github.com/DaITssu/daitssu-client/assets/96258104/24677a09-01d6-4758-80a0-de9c0025a2d0">
