### PR TITLE
[#174] 닉네임 중복체크, 회원탈퇴 API 연결 및 UI 수정

### DIFF
--- a/src/apis/authAPIS.ts
+++ b/src/apis/authAPIS.ts
@@ -83,3 +83,20 @@ export const getUserInfoAPI = async (studentId: string, password: string) => {
     }
   }
 };
+
+/**
+ * 닉네임 중복체크
+ * @param nickname: 유저 닉네임
+ */
+export const checkUserNickname = async (nickname: string) => {
+  try {
+    const response = await axiosInstance.get(
+      `/auth/check-nickname?nickname=${nickname}`,
+    );
+    return response.status;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      return error.status;
+    }
+  }
+};

--- a/src/apis/userAPIS.ts
+++ b/src/apis/userAPIS.ts
@@ -13,3 +13,15 @@ export const getUserAPI = async (userId: number) => {
     return null;
   }
 };
+
+/**
+ * 유저 삭제
+ */
+export const withdrawlAPI = async () => {
+  try {
+    const response = await axiosInstance.patch('/user');
+    return response.status;
+  } catch (error) {
+    return 500;
+  }
+};

--- a/src/components/Register/Register.styles.ts
+++ b/src/components/Register/Register.styles.ts
@@ -91,6 +91,12 @@ export const WarningText = styled.div`
   color: ${COLORS.SSU.error};
 `;
 
+export const CompleteText = styled.div`
+  margin-top: 20px;
+  ${TEXT_STYLES.CapR12};
+  color: ${COLORS.SSU.primary};
+`;
+
 export const EssentialText = styled.div`
   display: inline-block;
   color: ${COLORS.SSU.error};

--- a/src/components/Register/Register.tsx
+++ b/src/components/Register/Register.tsx
@@ -9,7 +9,7 @@ import Image from 'next/image';
 import TosItem from './TosItems/TosItem';
 import TOS from './TOS/TOS';
 import { UserInfoResponse } from '@/types/Auth';
-import { getUserInfoAPI } from '@/apis/authAPIS';
+import { getUserInfoAPI, checkUserNickname } from '@/apis/authAPIS';
 
 const Register = () => {
   const { query } = useRouter();
@@ -20,7 +20,7 @@ const Register = () => {
   const [isDuplicatedNickname, setIsDuplicatedNickname] =
     useState<boolean>(false);
 
-  const [checkNickname, setCheckNickName] = useState<boolean>(true);
+  const [checkNickname, setCheckNickName] = useState<boolean>(false);
   const [checkAllAgree, setCheckAllAgree] = useState<boolean>(false);
   const [checkPrivacy, setCheckPrivacy] = useState<boolean>(false);
   const [checkTermsOfUse, setCheckTermsOfUse] = useState<boolean>(false);
@@ -38,6 +38,19 @@ const Register = () => {
     setCheckTermsOfUse(newValue);
     setCheckThirdPartyInfo(newValue);
   }
+
+  const handleClickNicknameBtn = () => {
+    const response = checkUserNickname(nickname);
+    response.then((res) => {
+      if (res === 200) {
+        setCheckNickName(true);
+        setIsDuplicatedNickname(false);
+      } else {
+        setCheckNickName(false);
+        setIsDuplicatedNickname(true);
+      }
+    });
+  };
 
   useEffect(() => {
     if (checkPrivacy && checkTermsOfUse && checkThirdPartyInfo) {
@@ -72,9 +85,7 @@ const Register = () => {
               onChange={(e) => setNickname(e.target.value)}
             />
             <styles.RegisterNickNameInputButton
-              onClick={() => {
-                //TODO : 서버와 닉네임 중복확인
-              }}
+              onClick={handleClickNicknameBtn}
             >
               중복확인
             </styles.RegisterNickNameInputButton>
@@ -83,6 +94,11 @@ const Register = () => {
             <styles.WarningText>
               중복된 닉네임입니다. 다시 입력하세요
             </styles.WarningText>
+          )}
+          {!isDuplicatedNickname && checkNickname ? (
+            <styles.CompleteText>사용가능한 닉네임입니다.</styles.CompleteText>
+          ) : (
+            <></>
           )}
         </styles.Box>
         <div style={{ height: '16px' }}></div>

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -7,8 +7,10 @@ import NoticeFunSystemTab from '@/components/Home/NoticeFunSystemTab/NoticeFunSy
 import { useRouter } from 'next/router';
 import { useRecoilValue } from 'recoil';
 import { loginAtom } from '@/states/authAtom';
+import { useAxiosInterceptor } from '@/hooks/useAxiosInterceptor';
 
 const Header = () => {
+  useAxiosInterceptor();
   const router = useRouter();
   const [isHeaderVisible, setIsHeaderVisible] = useState(true);
   const [isSearchVisible, setIsSearchVisible] = useState(false);

--- a/src/components/myPage/setting/setting.style.ts
+++ b/src/components/myPage/setting/setting.style.ts
@@ -17,6 +17,19 @@ export const SettingBoxHeader = styled.div`
   color: var(--gray-2, #bdbdbd);
 `;
 
+export const SettingButton = styled.button`
+  width: 100%;
+  border: none;
+  background-color: white;
+  padding-top: 15px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding-bottom: 15px;
+  border-bottom: 1px solid ${COLORS.grayscale.Gray4};
+  text-align: start;
+`;
+
 export const SettingDiv = styled.div`
   padding-top: 15px;
   display: flex;

--- a/src/components/myPage/setting/setting.tsx
+++ b/src/components/myPage/setting/setting.tsx
@@ -1,11 +1,30 @@
-import React, { useState, useEffect } from 'react';
 import { TEXT_STYLES } from '@/styles/constants/textStyles';
 import RightArrow from '@icons/icon/Arrow/RightBigArrow1.svg';
+import { useRouter } from 'next/router';
 import Image from 'next/image';
 import * as styles from './setting.style';
 import Link from 'next/link';
+import {
+  loginAtom,
+  accessTokenAtom,
+  refreshTokenAtom,
+} from '@/states/authAtom';
+import { useResetRecoilState } from 'recoil';
 
 const Setting = () => {
+  const router = useRouter();
+
+  const resetLogin = useResetRecoilState(loginAtom);
+  const resetAccessToken = useResetRecoilState(accessTokenAtom);
+  const resetRefreshToken = useResetRecoilState(refreshTokenAtom);
+
+  const handleClickLogout = () => {
+    resetLogin();
+    resetAccessToken();
+    resetRefreshToken();
+    router.push('/');
+  };
+
   return (
     <styles.SettingStyle>
       <styles.SettingBox>
@@ -60,17 +79,14 @@ const Setting = () => {
       <div style={{ height: '20px' }}></div>
       <styles.SettingBox>
         <styles.SettingBoxHeader>로그아웃 및 탈퇴</styles.SettingBoxHeader>
-        <Link href={'/'}>
-          {/* 로그아웃 url 연결 */}
-          <styles.SettingDiv>
-            <styles.SettingDivText color="blue" style={TEXT_STYLES.HeadM18}>
-              로그아웃
-            </styles.SettingDivText>
-            <styles.SettinDivImg>
-              <Image src={RightArrow} width={24} height={24} alt="RightArrow" />
-            </styles.SettinDivImg>
-          </styles.SettingDiv>
-        </Link>
+        <styles.SettingButton onClick={handleClickLogout}>
+          <styles.SettingDivText color="blue" style={TEXT_STYLES.HeadM18}>
+            로그아웃
+          </styles.SettingDivText>
+          <styles.SettinDivImg>
+            <Image src={RightArrow} width={24} height={24} alt="RightArrow" />
+          </styles.SettinDivImg>
+        </styles.SettingButton>
         <Link href={'/my/withdrawal'}>
           {/* 탈퇴 하기 url 연결 */}
           <styles.SettingDiv>

--- a/src/components/myPage/withdrawal/withdrawal.style.ts
+++ b/src/components/myPage/withdrawal/withdrawal.style.ts
@@ -44,10 +44,10 @@ export const WithdrawalInput = styled.input`
   width: 100%;
   border: 1px solid ${COLORS.grayscale.Gray3};
   border-radius: 6px;
+  padding: 10px;
 
   ::placeholder {
     color: var(--gray-2, #bdbdbd);
-    padding: 10px;
     /* Caption R 14 */
     font-family: Pretendard;
     font-size: 14px;

--- a/src/components/myPage/withdrawal/withdrawal.style.ts
+++ b/src/components/myPage/withdrawal/withdrawal.style.ts
@@ -58,10 +58,14 @@ export const WithdrawalInput = styled.input`
   }
 `;
 
-export const WithdrawalButton = styled.div`
+export const WithdrawalButton = styled.button<{ active: boolean }>`
   background-color: ${COLORS.SSU.error};
+  background-color: ${(props) =>
+    props.active ? COLORS.SSU.error : COLORS.grayscale.Gray3};
   color: white;
   border-radius: 12px;
+  border: none;
+  width: 100%;
   height: 50px;
   display: flex;
   justify-content: center;

--- a/src/components/myPage/withdrawal/withdrawal.tsx
+++ b/src/components/myPage/withdrawal/withdrawal.tsx
@@ -9,6 +9,13 @@ import DefaultRadio from '/public/assets/icon/Radio/DefaultRadio.svg';
 
 import { withdrawlAPI } from '@/apis/userAPIS';
 
+import {
+  loginAtom,
+  accessTokenAtom,
+  refreshTokenAtom,
+} from '@/states/authAtom';
+import { useResetRecoilState } from 'recoil';
+
 const Withdrawal = () => {
   const [selectedIcon, setSelectedIcon] = useState<string | null>(null);
   const handleIconToggle = (icon: string) => {
@@ -26,6 +33,10 @@ const Withdrawal = () => {
 
   const router = useRouter();
 
+  const resetLogin = useResetRecoilState(loginAtom);
+  const resetAccessToken = useResetRecoilState(accessTokenAtom);
+  const resetRefreshToken = useResetRecoilState(refreshTokenAtom);
+
   const handleClickWithdrawlBtn = () => {
     const response = withdrawlAPI();
     response
@@ -33,6 +44,10 @@ const Withdrawal = () => {
         if (res === 200) {
           router.push('/');
           alert('회원탈퇴가 완료되었습니다.');
+          //로그아웃 처리
+          resetLogin();
+          resetAccessToken();
+          resetRefreshToken();
         } else {
           router.push('/');
           alert('회원탈퇴에 실패했습니다.');

--- a/src/components/myPage/withdrawal/withdrawal.tsx
+++ b/src/components/myPage/withdrawal/withdrawal.tsx
@@ -2,9 +2,12 @@ import React, { useState, useEffect } from 'react';
 import { TEXT_STYLES } from '@/styles/constants/textStyles';
 import Image from 'next/image';
 import { NextPage } from 'next';
+import { useRouter } from 'next/router';
 import * as styles from './withdrawal.style';
 import CheckedRadio from '/public/assets/icon/Radio/CheckedRadio.svg';
 import DefaultRadio from '/public/assets/icon/Radio/DefaultRadio.svg';
+
+import { withdrawlAPI } from '@/apis/userAPIS';
 
 const Withdrawal = () => {
   const [selectedIcon, setSelectedIcon] = useState<string | null>(null);
@@ -20,6 +23,27 @@ const Withdrawal = () => {
     '사용법이 어려움',
     '기타',
   ];
+
+  const router = useRouter();
+
+  const handleClickWithdrawlBtn = () => {
+    const response = withdrawlAPI();
+    response
+      .then((res) => {
+        if (res === 200) {
+          router.push('/');
+          alert('회원탈퇴가 완료되었습니다.');
+        } else {
+          router.push('/');
+          alert('회원탈퇴에 실패했습니다.');
+        }
+      })
+      .catch(() => {
+        router.push('/');
+        alert('회원탈퇴에 실패했습니다.');
+      });
+  };
+
   return (
     <styles.withdrawalStyle>
       <styles.withdrawalHeader style={TEXT_STYLES.HeadSM20}>
@@ -52,7 +76,12 @@ const Withdrawal = () => {
       <div style={{ height: '20px' }}></div>
       <styles.WithdrawalInput placeholder="해당 내용을 확인하고 탈퇴하겠습니다." />
       <div style={{ height: '20px' }}></div>
-      <styles.WithdrawalButton style={TEXT_STYLES.HeadM18}>
+      <styles.WithdrawalButton
+        disabled={selectedIcon ? false : true}
+        onClick={handleClickWithdrawlBtn}
+        style={TEXT_STYLES.HeadM18}
+        active={selectedIcon ? true : false}
+      >
         탈퇴하기
       </styles.WithdrawalButton>
     </styles.withdrawalStyle>

--- a/src/pages/layout/index.tsx
+++ b/src/pages/layout/index.tsx
@@ -6,13 +6,10 @@ import * as styles from './layout.style';
 import NavigationBar from '@/components/common/Navbar/NavigationBar';
 import useNavbar from '@/hooks/useNavbar';
 
-import { useAxiosInterceptor } from '@/hooks/useAxiosInterceptor';
-
 const MainLayout = ({ children }: PropsWithChildren<{}>) => {
   const activeNavType = useRecoilValue(userNavAtom).activeNavType;
 
   const { renderNavbar } = useNavbar();
-  useAxiosInterceptor();
   const [isShow, setIsShow] = useState(false);
 
   useEffect(() => {

--- a/src/pages/my/blockAccount/index.page.tsx
+++ b/src/pages/my/blockAccount/index.page.tsx
@@ -4,7 +4,6 @@ import BlockAccount from '@/components/myPage/blockAccount/blockAccount';
 export default function Home() {
   return (
     <>
-      <Header />
       <BlockAccount />
       {/* <NavigationBar focusType={'MY_PAGE'} /> */}
     </>

--- a/src/pages/my/editprofile/index.page.tsx
+++ b/src/pages/my/editprofile/index.page.tsx
@@ -4,7 +4,6 @@ import EditProfile from '@/components/myPage/EditProfile';
 export default function Home() {
   return (
     <>
-      <Header />
       <EditProfile />
     </>
   );

--- a/src/pages/my/scrap/index.page.tsx
+++ b/src/pages/my/scrap/index.page.tsx
@@ -5,8 +5,6 @@ import ScrapList from '@/components/myPage/Scrap/ScrapList';
 export default function Home() {
   return (
     <>
-      <Header />
-
       <ScrapList />
       <ScrapList />
       <ScrapList />

--- a/src/pages/my/setting/index.page.tsx
+++ b/src/pages/my/setting/index.page.tsx
@@ -1,11 +1,8 @@
-import Header from '@/components/common/Header/Header';
-import NavigationBar from '@/components/common/Navbar/NavigationBar';
 import Setting from '@/components/myPage/setting/setting';
 
 export default function Home() {
   return (
     <>
-      <Header />
       <Setting />
       {/* <NavigationBar focusType={'MY_PAGE'} /> */}
     </>

--- a/src/pages/my/withdrawal/index.page.tsx
+++ b/src/pages/my/withdrawal/index.page.tsx
@@ -4,7 +4,6 @@ import Withdrawal from '@/components/myPage/withdrawal/withdrawal';
 export default function Home() {
   return (
     <>
-      <Header />
       <Withdrawal />
       {/* <NavigationBar focusType={'MY_PAGE'} /> */}
     </>


### PR DESCRIPTION
## Issue

- Resolves #174 

## Description

- 회원가입시 닉네임 중복환인 API 연결, 검사 결과 UI에 반영
- 회원탈퇴 API 연결 -> 알림창으로 결과 알려주고 홈화면으로 이동

## Check List

- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] PR에 해당되는 Issue를 연결 완료
- [x] 적절한 라벨 설정
- [x] 작업한 사람 모두를 Assign
- [x] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인

## Screenshot
![화면 기록 2024-01-30 오후 9 48 18](https://github.com/DaITssu/daitssu-client/assets/70098708/3a68e901-6854-4258-96f2-9f295cb51c0e)
![화면 기록 2024-01-30 오후 9 46 29](https://github.com/DaITssu/daitssu-client/assets/70098708/bcee09ae-8e46-446b-8c9d-8aae8ecf5404)
