### PR TITLE
[#184]  로그인/회원가입시 에러 코드에 따라 분기, 토큰 refresh 에러 수정, 회원가입 API 연결

### DIFF
--- a/src/apis/authAPIS.ts
+++ b/src/apis/authAPIS.ts
@@ -10,6 +10,7 @@ const REFRESH_EXPIRY_TIME = 7 * 24 * 60 * 60 * 1000; // 7일
 
 const signInSuccess = (responseData: AuthResponse) => {
   LocalStorage.setItem('accessToken', responseData.data.accessToken.token);
+  LocalStorage.setItem('refreshToken', responseData.data.refreshToken.token);
   const refreshToken = LocalStorage.getItem('refreshToken');
 
   //accessToken 만료 1분전 로그인 연장
@@ -19,7 +20,7 @@ const signInSuccess = (responseData: AuthResponse) => {
         console.error(error);
       },
     );
-  }, ACCESS_EXPIRY_TIME);
+  }, ACCESS_EXPIRY_TIME - 10000);
 };
 
 const logout = () => {

--- a/src/apis/authAPIS.ts
+++ b/src/apis/authAPIS.ts
@@ -56,11 +56,7 @@ export const signInAPI = async (
         return resolve(response.data);
       })
       .catch((error) => {
-        if (axios.isAxiosError(error)) {
-          return reject(error.response?.data);
-        } else {
-          return reject(error);
-        }
+        return resolve(error.response?.data);
       });
   });
 };

--- a/src/apis/authAPIS.ts
+++ b/src/apis/authAPIS.ts
@@ -20,7 +20,7 @@ const signInSuccess = (responseData: AuthResponse) => {
         console.error(error);
       },
     );
-  }, ACCESS_EXPIRY_TIME - 10000);
+  }, ACCESS_EXPIRY_TIME - 60000);
 };
 
 const logout = () => {

--- a/src/apis/authAPIS.ts
+++ b/src/apis/authAPIS.ts
@@ -74,7 +74,7 @@ export const signInAPI = async (
 export const signUpAPI = async (
   nickname: string,
   name: string,
-  departmentId: number,
+  departmentName: string,
   studentId: string,
   term: number,
 ) => {
@@ -82,7 +82,7 @@ export const signUpAPI = async (
     const response = await axiosInstance.post('/auth/sign-up', {
       nickname,
       name,
-      departmentId,
+      departmentName,
       studentId,
       term,
     });

--- a/src/components/Register/Register.styles.ts
+++ b/src/components/Register/Register.styles.ts
@@ -24,7 +24,10 @@ export const BoxInnerText = styled.div`
   color: ${COLORS.grayscale.Gray1};
 `;
 
-export const RegisterNickNameInput = styled.input<{ isDuplicated: boolean }>`
+export const RegisterNickNameInput = styled.input<{
+  isDuplicated: boolean;
+  checkNickname: boolean;
+}>`
   border-radius: 6px;
   background-color: white;
   border: 1px solid
@@ -34,8 +37,10 @@ export const RegisterNickNameInput = styled.input<{ isDuplicated: boolean }>`
   height: 48px;
   padding: 12px 60px 12px 8px;
   &:focus {
-    outline: 2px solid ${COLORS.SSU.primary};
+    border: 1px solid ${COLORS.SSU.primary};
   }
+  outline: ${(prop) =>
+    prop.checkNickname ? `1px solid ${COLORS.SSU.primary}` : 'none'};
 `;
 
 export const TosItemStyle = styled.div`

--- a/src/components/Register/Register.styles.ts
+++ b/src/components/Register/Register.styles.ts
@@ -33,6 +33,9 @@ export const RegisterNickNameInput = styled.input<{ isDuplicated: boolean }>`
   width: 100%;
   height: 48px;
   padding: 12px 60px 12px 8px;
+  &:focus {
+    outline: 2px solid ${COLORS.SSU.primary};
+  }
 `;
 
 export const TosItemStyle = styled.div`
@@ -60,19 +63,20 @@ export const RegisterNickNameInputButton = styled.button`
   cursor: pointer;
 `;
 
-export const RegisterTextArea = styled.input`
+export const RegisterTextArea = styled.div`
   ${TEXT_STYLES.BodyR16};
   color: ${COLORS.grayscale.Gray1};
   background-color: ${COLORS.grayscale.Gray5};
   border: 1px solid ${COLORS.grayscale.Gray4};
   width: 100%;
+  height: 45px;
   padding: 12px 8px 12px 8px;
   border-radius: 6px;
   margin-bottom: 12px;
   outline: none;
 `;
 
-export const ConfirmButton = styled.div<{ isCheck: boolean }>`
+export const ConfirmButton = styled.button<{ isCheck: boolean }>`
   ${TEXT_STYLES.HeadM18}
   height: 50px;
   color: white;
@@ -82,6 +86,7 @@ export const ConfirmButton = styled.div<{ isCheck: boolean }>`
   width: 100%;
   background-color: ${(props) =>
     props.isCheck ? COLORS.SSU.primary : COLORS.grayscale.Gray3};
+  border: none;
   border-radius: 12px;
 `;
 

--- a/src/components/Register/Register.tsx
+++ b/src/components/Register/Register.tsx
@@ -119,8 +119,12 @@ const Register = () => {
           <div style={{ position: 'relative', marginBottom: '5px' }}>
             <styles.RegisterNickNameInput
               isDuplicated={isDuplicatedNickname}
+              checkNickname={checkNickname}
               value={nickname}
-              onChange={(e) => setNickname(e.target.value)}
+              onChange={(e) => {
+                setNickname(e.target.value);
+                setCheckNickName(false);
+              }}
             />
             <styles.RegisterNickNameInputButton
               onClick={handleClickNicknameBtn}

--- a/src/components/Register/Register.tsx
+++ b/src/components/Register/Register.tsx
@@ -9,10 +9,11 @@ import Image from 'next/image';
 import TosItem from './TosItems/TosItem';
 import TOS from './TOS/TOS';
 import { UserInfoResponse } from '@/types/Auth';
-import { getUserInfoAPI, checkUserNickname } from '@/apis/authAPIS';
+import { getUserInfoAPI, checkUserNickname, signUpAPI } from '@/apis/authAPIS';
 
 const Register = () => {
   const { query } = useRouter();
+  const router = useRouter();
   const [userInfo, setUserInfo] = useState<UserInfoResponse>();
   const [showModal, setShowModal] = useState(false);
 
@@ -50,6 +51,43 @@ const Register = () => {
         setIsDuplicatedNickname(true);
       }
     });
+  };
+
+  const handleClickConfirmButton = () => {
+    const response = signUpAPI(
+      nickname,
+      userInfo?.data?.name || '',
+      userInfo?.data?.department || '',
+      userInfo?.data?.studentId || '',
+      Number(userInfo?.data?.term[4]),
+    );
+    response
+      .then((res) => {
+        if (res?.code === 0) {
+          router.push(
+            {
+              pathname: '/login',
+              query: {
+                message: '회원가입에 성공했습니다.',
+              },
+            },
+            '/login',
+          );
+        } else {
+          throw new Error();
+        }
+      })
+      .catch(() => {
+        router.push(
+          {
+            pathname: '/login',
+            query: {
+              message: '회원가입에 실패했습니다.',
+            },
+          },
+          '/login',
+        );
+      });
   };
 
   useEffect(() => {
@@ -105,19 +143,21 @@ const Register = () => {
         <styles.Box>
           <styles.BoxHeaderText>회원 정보를 확인해주세요</styles.BoxHeaderText>
           <styles.BoxInnerText>이름</styles.BoxInnerText>
-          <styles.RegisterTextArea
-            readOnly
-            value={userInfo?.data?.name || ''}
-          />
+          <styles.RegisterTextArea>
+            {userInfo?.data?.name}
+          </styles.RegisterTextArea>
           <styles.BoxInnerText>학부</styles.BoxInnerText>
-          <styles.RegisterTextArea readOnly value="글로벌미디어학부" />
+          <styles.RegisterTextArea>
+            {userInfo?.data?.department}
+          </styles.RegisterTextArea>
           <styles.BoxInnerText>학번</styles.BoxInnerText>
-          <styles.RegisterTextArea readOnly value={query?.studentId || ''} />
+          <styles.RegisterTextArea>
+            {userInfo?.data?.studentId}
+          </styles.RegisterTextArea>
           <styles.BoxInnerText>학년/학기</styles.BoxInnerText>
-          <styles.RegisterTextArea
-            readOnly
-            value={userInfo?.data?.term || ''}
-          />
+          <styles.RegisterTextArea>
+            {userInfo?.data?.term}
+          </styles.RegisterTextArea>
         </styles.Box>
         <div style={{ height: '16px' }}></div>
         <styles.Box>
@@ -194,6 +234,10 @@ const Register = () => {
           <styles.ConfirmButton
             isCheck={
               checkPrivacy && checkNickname && checkTermsOfUse ? true : false
+            }
+            onClick={handleClickConfirmButton}
+            disabled={
+              checkPrivacy && checkNickname && checkTermsOfUse ? false : true
             }
           >
             완료

--- a/src/components/Register/TosItems/TosItem.styles.ts
+++ b/src/components/Register/TosItems/TosItem.styles.ts
@@ -7,6 +7,7 @@ export const TosItemStyle = styled.div`
   display: flex;
   align-items: center;
   cursor: pointer;
+  position: relative;
 `;
 
 export const TosItemImageDiv = styled.div`

--- a/src/components/common/InputBox/InputBox.styles.ts
+++ b/src/components/common/InputBox/InputBox.styles.ts
@@ -40,4 +40,8 @@ export const Input = styled.input<{ width?: string; height?: string }>`
     -webkit-appearance: none;
     margin: 0;
   }
+
+  &:focus {
+    border: 1px solid ${COLORS.SSU.primary};
+  }
 `;

--- a/src/components/landing/AuthContent/AuthContent.style.ts
+++ b/src/components/landing/AuthContent/AuthContent.style.ts
@@ -21,7 +21,7 @@ export const LoginButton = styled(Button)`
 export const AuthCheckBtnContainer = styled.div`
   width: 180px;
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
 `;
 
 export const AuthCheckBtn = styled.button`

--- a/src/components/landing/AuthContent/AuthContent.tsx
+++ b/src/components/landing/AuthContent/AuthContent.tsx
@@ -15,8 +15,13 @@ const AuthContent = () => {
         로그인
       </styles.LoginButton>
       <styles.AuthCheckBtnContainer>
-        <styles.AuthCheckBtn>아이디/비밀번호 찾기</styles.AuthCheckBtn>
-        <styles.AuthCheckBtn>회원가입</styles.AuthCheckBtn>
+        <styles.AuthCheckBtn
+          onClick={() => {
+            window.open('https://lms.ssu.ac.kr/login');
+          }}
+        >
+          아이디/비밀번호 찾기
+        </styles.AuthCheckBtn>
       </styles.AuthCheckBtnContainer>
     </styles.AuthContentContainer>
   );

--- a/src/components/landing/index.tsx
+++ b/src/components/landing/index.tsx
@@ -15,6 +15,7 @@ const Landing = () => {
         alt="배경 이미지"
         fill
         style={{ objectFit: 'cover' }}
+        priority
       />
       <LandingLogo />
       <AuthContent />

--- a/src/components/login/FindAccount/FindAccountLayout.tsx
+++ b/src/components/login/FindAccount/FindAccountLayout.tsx
@@ -6,9 +6,9 @@ export default function FindAccountLayout() {
 
   const handleClickFindButton = (type: 'ID' | 'Password') => {
     if (type === 'ID')
-      router.push('https://smartid.ssu.ac.kr/Symtra_Sso/smln_IDFind.asp');
+      window.open('https://smartid.ssu.ac.kr/Symtra_Sso/smln_IDFind.asp');
     if (type === 'Password')
-      router.push('https://smartid.ssu.ac.kr/Symtra_Sso/smln_pwd.asp');
+      window.open('https://smartid.ssu.ac.kr/Symtra_Sso/smln_pwd.asp');
   };
 
   return (

--- a/src/components/login/LoginLayout/LoginLayout.tsx
+++ b/src/components/login/LoginLayout/LoginLayout.tsx
@@ -49,10 +49,12 @@ export default function LoginLayout() {
           //로그인 성공
           LocalStorage.setItem('isLogin', 'true');
           router.push('/');
+          return res;
         } else if (res?.code === 1011) {
           //비밀번호 틀림
           setMessage('패스워드가 일치하지 않습니다.');
           setPassword('');
+          return res;
         } else if (res?.code === 1001) {
           //유저 없음
           return fetchUserInfo().then((userInfoRes) => {
@@ -69,13 +71,12 @@ export default function LoginLayout() {
                 },
                 '/register', //마스킹해서 브라우저에 query 안보이게
               );
-              return Promise.resolve(res);
             } else {
               valid = false;
               setMessage('패스워드가 일치하지 않습니다.');
               setPassword('');
-              return res;
             }
+            return res;
           });
         }
       })

--- a/src/components/login/LoginLayout/LoginLayout.tsx
+++ b/src/components/login/LoginLayout/LoginLayout.tsx
@@ -54,32 +54,34 @@ export default function LoginLayout() {
           setPassword('');
         } else if (res?.code === 1001) {
           //유저 없음
-          fetchUserInfo();
-          if (isValid) {
-            //회원가입
-            router.push(
-              {
-                pathname: '/register',
-                query: {
-                  studentId: ID,
-                  password,
+          return fetchUserInfo().then((userInfoRes) => {
+            if (userInfoRes) {
+              //회원가입
+              router.push(
+                {
+                  pathname: '/register',
+                  query: {
+                    studentId: ID,
+                    password,
+                  },
                 },
-              },
-              '/register', //마스킹해서 브라우저에 query 안보이게
-            );
-          } else {
-            setMessage('패스워드가 일치하지 않습니다.');
-            setPassword('');
-          }
-        } else {
-          //로그인 실패
-          setMessage('로그인에 실패했습니다.');
-          setPassword('');
+                '/register', //마스킹해서 브라우저에 query 안보이게
+              );
+            } else {
+              setMessage('패스워드가 일치하지 않습니다.');
+              setPassword('');
+            }
+            return res;
+          });
         }
-        return res;
       })
       .then((res) => {
         if (res?.code !== 0 && !isValid) open(); //에러 메시지 모달 open
+      })
+      .catch(() => {
+        //로그인 실패
+        setMessage('로그인에 실패했습니다.');
+        setPassword('');
       });
   };
 

--- a/src/components/myPage/withdrawal/withdrawal.style.ts
+++ b/src/components/myPage/withdrawal/withdrawal.style.ts
@@ -56,6 +56,10 @@ export const WithdrawalInput = styled.input`
     line-height: 150%; /* 21px */
     letter-spacing: -0.154px;
   }
+
+  &:focus {
+    outline: none;
+  }
 `;
 
 export const WithdrawalButton = styled.button<{ active: boolean }>`

--- a/src/components/myPage/withdrawal/withdrawal.tsx
+++ b/src/components/myPage/withdrawal/withdrawal.tsx
@@ -13,6 +13,9 @@ import LocalStorage from '@/utils/localStorage';
 
 const Withdrawal = () => {
   const [selectedIcon, setSelectedIcon] = useState<string | null>(null);
+  const [writeInput, setWriteInput] = useState<string>('');
+  const [isWrited, setIsWrited] = useState<boolean>(false);
+
   const handleIconToggle = (icon: string) => {
     setSelectedIcon(icon);
   };
@@ -50,6 +53,16 @@ const Withdrawal = () => {
       });
   };
 
+  const handleChangeWriteInput = (e: React.FormEvent<HTMLInputElement>) => {
+    setWriteInput(e.currentTarget.value);
+    const pattern = /해당\s*내용을\s*확인하고\s*탈퇴하겠습니다/;
+    if (pattern.test(e.currentTarget.value)) {
+      setIsWrited(true);
+    } else {
+      setIsWrited(false);
+    }
+  };
+
   return (
     <styles.withdrawalStyle>
       <styles.withdrawalHeader style={TEXT_STYLES.HeadSM20}>
@@ -62,7 +75,7 @@ const Withdrawal = () => {
       </styles.withdrawalHeaderText>
       <div style={{ height: '20px' }}></div>
       <div>
-        {ReportText.map((res, index) => (
+        {ReportText.map((res) => (
           <WithdrawalItem
             text={res}
             isSelected={selectedIcon === res}
@@ -80,13 +93,17 @@ const Withdrawal = () => {
       <div style={{ height: '20px' }}></div>
       <div style={TEXT_STYLES.CapM14}>탈퇴 확인 입력</div>
       <div style={{ height: '20px' }}></div>
-      <styles.WithdrawalInput placeholder="해당 내용을 확인하고 탈퇴하겠습니다." />
+      <styles.WithdrawalInput
+        value={writeInput}
+        onChange={handleChangeWriteInput}
+        placeholder="해당 내용을 확인하고 탈퇴하겠습니다."
+      />
       <div style={{ height: '20px' }}></div>
       <styles.WithdrawalButton
-        disabled={selectedIcon ? false : true}
+        disabled={selectedIcon && isWrited ? false : true}
         onClick={handleClickWithdrawlBtn}
         style={TEXT_STYLES.HeadM18}
-        active={selectedIcon ? true : false}
+        active={selectedIcon && isWrited ? true : false}
       >
         탈퇴하기
       </styles.WithdrawalButton>

--- a/src/hooks/useCheckLogin.ts
+++ b/src/hooks/useCheckLogin.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import LocalStorage from '@/utils/localStorage';
+
+const useCheckLogin = () => {
+  const router = useRouter();
+
+  useEffect(() => {
+    const isLogin = Boolean(LocalStorage.getItem('isLogin'));
+    if (
+      !isLogin &&
+      router.pathname !== '/landing' &&
+      router.pathname !== '/login'
+    ) {
+      router.push('/landing');
+    }
+  }, []);
+};
+
+export default useCheckLogin;

--- a/src/hooks/useValidUser.ts
+++ b/src/hooks/useValidUser.ts
@@ -12,13 +12,14 @@ export const useValidUser = (
       const response = await getUserInfoAPI(String(studentId), password);
       if (response.code === 0) {
         setIsValid(true);
+        return true;
       } else {
         setIsValid(false);
+        return false;
       }
-      return;
     } catch (error) {
       setIsValid(false);
-      return;
+      return false;
     }
   };
 

--- a/src/hooks/useValidUser.ts
+++ b/src/hooks/useValidUser.ts
@@ -1,0 +1,26 @@
+import { getUserInfoAPI } from '@/apis/authAPIS';
+import { useState } from 'react';
+
+export const useValidUser = (
+  studentId: number | undefined,
+  password: string,
+) => {
+  const [isValid, setIsValid] = useState<boolean>(false);
+
+  const fetchUserInfo = async () => {
+    try {
+      const response = await getUserInfoAPI(String(studentId), password);
+      if (response.code === 0) {
+        setIsValid(true);
+      } else {
+        setIsValid(false);
+      }
+      return;
+    } catch (error) {
+      setIsValid(false);
+      return;
+    }
+  };
+
+  return { isValid, fetchUserInfo };
+};

--- a/src/hooks/useValidUser.ts
+++ b/src/hooks/useValidUser.ts
@@ -5,23 +5,18 @@ export const useValidUser = (
   studentId: number | undefined,
   password: string,
 ) => {
-  const [isValid, setIsValid] = useState<boolean>(false);
-
   const fetchUserInfo = async () => {
     try {
       const response = await getUserInfoAPI(String(studentId), password);
       if (response.code === 0) {
-        setIsValid(true);
         return true;
       } else {
-        setIsValid(false);
         return false;
       }
     } catch (error) {
-      setIsValid(false);
       return false;
     }
   };
 
-  return { isValid, fetchUserInfo };
+  return { fetchUserInfo };
 };

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -9,9 +9,11 @@ import {
 import { useState } from 'react';
 import { RecoilRoot } from 'recoil';
 import Header from '@/components/common/Header/Header';
+import useCheckLogin from '@/hooks/useCheckLogin';
 
 export default function App({ Component, pageProps }: AppProps) {
   const [queryClient] = useState(() => new QueryClient());
+  useCheckLogin();
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/src/types/Auth.ts
+++ b/src/types/Auth.ts
@@ -20,5 +20,6 @@ export interface UserInfoResponse {
     name: string;
     studentId: string;
     term: string;
+    department: string;
   };
 }


### PR DESCRIPTION
## Issue

- Resolves #184 

## Description

- 로그인 api 호출시 에러 코드에 따라 분기 및 모달로 에러 메시지 출력
- 회원가입시 기존 회원인지 여부에 따라서 에러 처리
- 미로그인 상태로 다른 페이지 접근시 이동 처리
- 토큰 refresh시 1번만 실행되는 에러 찾아서 fix (refresh API 호출시 refresh Token을 교체하지 않아서 생겼던 문제)

+) 랜딩페이지에서 아이디/비밀번호 찾기 동작 추가 (새 창으로 열림)

- 회원가입 API 연결 - 실패시 로그인 페이지로 이동하고 안내 모달
- input창 focus시 border 색깔 효과 추가

## Check List

- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] PR에 해당되는 Issue를 연결 완료
- [x] 적절한 라벨 설정
- [x] 작업한 사람 모두를 Assign
- [x] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인

## Screenshot
