### PR TITLE
[#192] 상세정보 수정

### DIFF
--- a/src/components/common/Header/UtilityHeader.tsx
+++ b/src/components/common/Header/UtilityHeader.tsx
@@ -17,6 +17,7 @@ export interface UtilityHeaderProps {
   onClickDeleteBtn?: Function; // "삭제" 버튼 클릭 시 동작
   isConfirmBtn?: boolean; //"확인"버튼 존재여부
   onClickConfrimBtn?: Function; // "확인 버튼 클릭 시 동작
+  mainClickBack?: Function; // 상세정보에서 back하면 해당 라우터로 변경하도록 (main)
 }
 
 const UtilityHeader = ({
@@ -29,6 +30,7 @@ const UtilityHeader = ({
   isPossibleDelete = false,
   isConfirmBtn = false,
   onClickConfrimBtn = () => {},
+  mainClickBack,
 }: UtilityHeaderProps) => {
   const router = useRouter();
 
@@ -39,7 +41,11 @@ const UtilityHeader = ({
       <styles.Conatiner>
         <styles.LogoLeftImg
           onClick={() => {
-            router.back();
+            if (mainClickBack) {
+              mainClickBack();
+            } else {
+              router.back();
+            }
           }}
         >
           <Image src={LeftArrow} width={25} height={25} alt="headerLeftArrow" />

--- a/src/components/myPage/home/home.tsx
+++ b/src/components/myPage/home/home.tsx
@@ -83,7 +83,7 @@ const MyPageComponent = () => {
             <Image src={rightArrow} width={20} height={20} alt="go" />
           </styles.Content>
         </Link>
-        <Link href="/my/contents" style={{ textDecoration: 'none' }}>
+        <Link href="/my/post" style={{ textDecoration: 'none' }}>
           <styles.Content>
             <styles.ContentDetil>
               <Image

--- a/src/components/notice/info/NoticeInfo.tsx
+++ b/src/components/notice/info/NoticeInfo.tsx
@@ -55,6 +55,13 @@ const NoticeInfo = () => {
     }
   }
 
+  const HeaderName = (path: string) => {
+    if (extractCategoryFromUrl(path) === 'notice') return '공지사항';
+    else if (extractCategoryFromUrl(path) === 'funsystem') return '펀시스템';
+    else if (extractCategoryFromUrl(path) === 'community') return '커뮤니티';
+    else return '';
+  };
+
   useEffect(() => {
     // 공지사항 API 연결
     if (extractCategoryFromUrl(path) === 'notice') {
@@ -159,7 +166,7 @@ const NoticeInfo = () => {
 
   return (
     <styles.Container>
-      <UtilityHeader child="공지사항" />
+      <UtilityHeader child={HeaderName(path)} />
       <styles.InfoBox>
         <styles.TypeBox>
           {data !== undefined && getKor(data?.category)}

--- a/src/components/notice/info/NoticeInfo.tsx
+++ b/src/components/notice/info/NoticeInfo.tsx
@@ -162,7 +162,12 @@ const NoticeInfo = () => {
 
   return (
     <styles.Container>
-      <UtilityHeader child={HeaderName(path)} />
+      <UtilityHeader
+        child={HeaderName(path)}
+        mainClickBack={() => {
+          router.push(`/${extractCategoryFromUrl(path)}`);
+        }}
+      />
       <styles.InfoBox>
         <styles.TypeBox>
           {data !== undefined && getKor(data?.category)}

--- a/src/components/notice/info/NoticeInfo.tsx
+++ b/src/components/notice/info/NoticeInfo.tsx
@@ -88,7 +88,7 @@ const NoticeInfo = () => {
         setComments(res.data);
       });
     }
-  }, []);
+  }, [pathId]);
 
   // 클립보드에 링크 복사
   const handleCopyClipBoard = async () => {

--- a/src/components/notice/info/NoticeInfo.tsx
+++ b/src/components/notice/info/NoticeInfo.tsx
@@ -1,5 +1,5 @@
 import * as styles from './NoticeInfo.style';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import Comment from '@/components/common/Comment';
 import CommentInput from '@/components/common/Comment/CommentInput';
@@ -10,10 +10,6 @@ import Download from '@icons/icon/Icon24/Download.svg';
 import Calendar from '@icons/icon/Nav/calendar_off.svg';
 import Url from '@icons/icon/Icon18/Url.svg';
 import Kakao from '@icons/icon/Icon18/Kakao.svg';
-import {
-  getCommunityInfoAPI,
-  getCommunityInfoCommentAPI,
-} from '@/apis/communityAPIS';
 import { Comments, NoticeInfoProps } from '@/types/NoticeFunsystem';
 import UtilityHeader from '@/components/common/Header/UtilityHeader';
 import { useRouter } from 'next/router';


### PR DESCRIPTION
## Issue

- Resolves #192 

## Description
- 상세페이지 헤더 제목 공지사항으로 고정되어 있는거 수정
- 새로고침시 라우터 안되는거 수정
- 상세페이지에서 뒤로가기시 무조건 공지사항/펀시스템/커뮤니티로 넘어가도록하기
-> 이부분 유틸리티 헤더를 건드려서 작업을 했는데 유틸리티 헤더 사용하는 다른 페이지에서 문제 없는건 확인했지만 뭔가,, 살짝 찜찜하네요 🥲
## Check List

- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] PR에 해당되는 Issue를 연결 완료
- [x] 적절한 라벨 설정
- [x] 작업한 사람 모두를 Assign
- [x] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인

## Screenshot
