### PR TITLE
[#204] 네비바 출현 (캘린더, 마이페이지

### DIFF
--- a/src/components/Calendar/CalendarScreen/CalendarScreen.tsx
+++ b/src/components/Calendar/CalendarScreen/CalendarScreen.tsx
@@ -46,6 +46,9 @@ const CalendarScreen = () => {
   const [dailyTasks, setDailyTasks] = useState<CalendersResponse[]>([]);
 
   function onDayClick(day: number) {
+    if (day === -1) {
+      return;
+    }
     setSelectDay(day);
     var dailyTaskList: CalendersResponse[] = [];
     for (let i = 0; i < monthlyTasks.length; i++) {

--- a/src/components/common/Navbar/NavInfo.ts
+++ b/src/components/common/Navbar/NavInfo.ts
@@ -28,9 +28,9 @@ export const NAV_INFO = {
       default: Home_Off,
     },
   },
-  [NAV_LIST.ANNOUNCEMENT]: {
+  [NAV_LIST.NOTICE]: {
     label: '공지사항',
-    url: NAV_URL_LIST.ANNOUNCEMENT,
+    url: NAV_URL_LIST.NOTICE,
     icon: {
       active: Anouncement_On,
       default: Anouncement_Off,

--- a/src/components/common/Navbar/Navbar.stories.tsx
+++ b/src/components/common/Navbar/Navbar.stories.tsx
@@ -23,7 +23,7 @@ export const Community: Story = {
 };
 export const Announcement: Story = {
   args: {
-    focusType: 'ANNOUNCEMENT',
+    focusType: 'NOTICE',
   },
 };
 export const Calendar: Story = {

--- a/src/components/common/Navbar/Navigation.ts
+++ b/src/components/common/Navbar/Navigation.ts
@@ -1,14 +1,14 @@
 export const NAV_LIST = {
   HOME: 'HOME',
   COMMUNITY: 'COMMUNITY',
-  ANNOUNCEMENT: 'ANNOUNCEMENT',
+  NOTICE: 'NOTICE',
   CALENDAR: 'CALENDAR',
   MY_PAGE: 'MY_PAGE',
 } as const;
 
 export const NAV_URL_LIST = {
   [NAV_LIST.HOME]: '/',
-  [NAV_LIST.ANNOUNCEMENT]: '/notice',
+  [NAV_LIST.NOTICE]: '/notice',
   [NAV_LIST.COMMUNITY]: '/community',
   [NAV_LIST.CALENDAR]: '/calendar',
   [NAV_LIST.MY_PAGE]: '/my',

--- a/src/components/common/Navbar/NavigationBar.style.ts
+++ b/src/components/common/Navbar/NavigationBar.style.ts
@@ -10,7 +10,7 @@ export const Navigaton = styled.div<{ render: boolean }>`
   background-color: ${COLORS.grayscale.white};
   display: ${(props) => (props.render ? 'flex' : 'none')};
 
-  @keyframes fadeInUp {
+  /* @keyframes fadeInUp {
     0% {
       opacity: 0;
       transform: translate3d(0, 100%, 0);
@@ -19,8 +19,8 @@ export const Navigaton = styled.div<{ render: boolean }>`
       opacity: 1;
       transform: translateZ(0);
     }
-  }
-  animation: fadeInUp 0.5s;
+  } 
+  animation: fadeInUp 0.5s; */
 `;
 
 export const IconContainer = styled.div``;

--- a/src/components/common/Navbar/NavigationBar.tsx
+++ b/src/components/common/Navbar/NavigationBar.tsx
@@ -12,8 +12,8 @@ const NavigationBar = ({ focusType, render = true }: NavigationBarProps) => {
     <>
       <styles.Navigaton render={render}>
         <NavItem
-          type={NAV_LIST.ANNOUNCEMENT}
-          isFocused={focusType === NAV_LIST.ANNOUNCEMENT}
+          type={NAV_LIST.NOTICE}
+          isFocused={focusType === NAV_LIST.NOTICE}
         />
         <NavItem
           type={NAV_LIST.COMMUNITY}

--- a/src/components/myPage/home/home.styles.tsx
+++ b/src/components/myPage/home/home.styles.tsx
@@ -6,6 +6,7 @@ export const ContentList = styled.div`
   display: flex;
   flex-direction: column;
   margin-top: 20px;
+  padding-right: 20px;
 `;
 
 export const Content = styled.div`

--- a/src/components/myPage/home/home.tsx
+++ b/src/components/myPage/home/home.tsx
@@ -65,7 +65,7 @@ const MyPageComponent = () => {
       //TODO : 나의 과목 부분 6-2 부분 지정되고 추가 예정
        */}
       <styles.ContentList style={{ textDecoration: 'none' }}>
-        <Link href="/my/subscribe" style={{ textDecoration: 'none' }}>
+        {/* <Link href="/my/subscribe" style={{ textDecoration: 'none' }}>
           <styles.Content>
             <styles.ContentDetil>
               <Image
@@ -79,7 +79,7 @@ const MyPageComponent = () => {
             </styles.ContentDetil>
             <Image src={rightArrow} width={20} height={20} alt="go" />
           </styles.Content>
-        </Link>
+        </Link> */}
         <Link href="/my/post" style={{ textDecoration: 'none' }}>
           <styles.Content>
             <styles.ContentDetil>

--- a/src/hooks/useNavbar.ts
+++ b/src/hooks/useNavbar.ts
@@ -5,7 +5,7 @@ import { useState, useEffect } from 'react';
  */
 const useNavbar = () => {
   const [isLogin, setIsLogin] = useState(true); //TODO: 추후 전역 상태에서 가져옴
-  const [renderNavbar, setRenderNavbar] = useState(false);
+  const [renderNavbar, setRenderNavbar] = useState(true);
 
   function onScroll() {
     if (screen.height * 0.8 < window.scrollY) {

--- a/src/pages/calendar/index.page.tsx
+++ b/src/pages/calendar/index.page.tsx
@@ -1,9 +1,23 @@
+import { userNavAtom } from '@/states/userNavAtom';
 import CalendarScreen from '@/components/Calendar/CalendarScreen';
+import MainLayout from '../layout';
+import { useRecoilState, useSetRecoilState } from 'recoil';
+import { use, useState } from 'react';
 
 export default function Calendar() {
+  const getNavData = useRecoilState(userNavAtom);
+  const setNavData = useSetRecoilState(userNavAtom);
+
+  useState(() => {
+    setNavData({
+      ...getNavData,
+      activeNavType: 'CALENDAR',
+    });
+  });
+
   return (
-    <>
+    <MainLayout>
       <CalendarScreen />
-    </>
+    </MainLayout>
   );
 }

--- a/src/pages/community/index.page.tsx
+++ b/src/pages/community/index.page.tsx
@@ -1,7 +1,18 @@
 import CommunityList from '@/components/community/list/CommunityList';
 import MainLayout from '../layout';
+import { useState } from 'react';
+import { userNavAtom } from '@/states/userNavAtom';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 
 export default function Home() {
+  const getNavData = useRecoilState(userNavAtom);
+  const setNavData = useSetRecoilState(userNavAtom);
+  useState(() => {
+    setNavData({
+      ...getNavData,
+      activeNavType: 'COMMUNITY',
+    });
+  });
   return (
     <MainLayout>
       <CommunityList isButtonVisible={true} search="" />

--- a/src/pages/funsystem/index.page.tsx
+++ b/src/pages/funsystem/index.page.tsx
@@ -1,6 +1,8 @@
 import TopTab from '@/components/notice/TopTab';
 import MainLayout from '../layout';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import { useRecoilState, useSetRecoilState } from 'recoil';
+import { userNavAtom } from '@/states/userNavAtom';
 
 export default function Home() {
   useEffect(() => {
@@ -9,6 +11,14 @@ export default function Home() {
       document.body.style.overflow = '';
     };
   }, []);
+  const getNavData = useRecoilState(userNavAtom);
+  const setNavData = useSetRecoilState(userNavAtom);
+  useState(() => {
+    setNavData({
+      ...getNavData,
+      activeNavType: 'NOTICE',
+    });
+  });
   return (
     <>
       <MainLayout />

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -2,7 +2,6 @@ import MainLayout from './layout';
 import { useEffect } from 'react';
 import { useSetRecoilState, useRecoilValue } from 'recoil';
 import { userNavAtom, IUserNavAtom } from '@/states/userNavAtom';
-import { NAV_LIST } from '@/components/common/Navbar/Navigation';
 import '../styles/Home.module.css';
 import Main from '@/components/main';
 import LocalStorage from '@/utils/localStorage';
@@ -10,9 +9,7 @@ import { useRouter } from 'next/router';
 
 const MainPage = () => {
   const setNavAtom = useSetRecoilState(userNavAtom);
-  const navState: IUserNavAtom = {
-    activeNavType: NAV_LIST.HOME,
-  };
+  const getNavData = useRecoilValue(userNavAtom);
 
   const router = useRouter();
 
@@ -21,6 +18,10 @@ const MainPage = () => {
 
   //mobile height size 설정
   useEffect(() => {
+    setNavAtom({
+      ...getNavData,
+      activeNavType: 'HOME',
+    });
     // 미로그인 상태면 랜딩 페이지로 이동
     if (!isLogin) {
       router.push('/landing');

--- a/src/pages/my/index.page.tsx
+++ b/src/pages/my/index.page.tsx
@@ -1,5 +1,22 @@
 import EditProfile from '@/components/myPage/home';
+import { useState } from 'react';
+import MainLayout from '../layout';
+import { useRecoilState, useSetRecoilState } from 'recoil';
+import { userNavAtom } from '@/states/userNavAtom';
 
 export default function Home() {
-  return <EditProfile />;
+  const getNavData = useRecoilState(userNavAtom);
+  const setNavData = useSetRecoilState(userNavAtom);
+  useState(() => {
+    setNavData({
+      ...getNavData,
+      activeNavType: 'MY_PAGE',
+    });
+  });
+
+  return (
+    <MainLayout>
+      <EditProfile />
+    </MainLayout>
+  );
 }

--- a/src/pages/my/setting/index.page.tsx
+++ b/src/pages/my/setting/index.page.tsx
@@ -1,10 +1,11 @@
+import UtilityHeader from '@/components/common/Header/UtilityHeader';
 import Setting from '@/components/myPage/setting/setting';
 
 export default function Home() {
   return (
     <>
+      <UtilityHeader child="설정" />
       <Setting />
-      {/* <NavigationBar focusType={'MY_PAGE'} /> */}
     </>
   );
 }

--- a/src/pages/notice/index.page.tsx
+++ b/src/pages/notice/index.page.tsx
@@ -1,8 +1,18 @@
 import TopTab from '@/components/notice/TopTab';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import MainLayout from '../layout';
+import { useRecoilState, useSetRecoilState } from 'recoil';
+import { userNavAtom } from '@/states/userNavAtom';
 
 export default function Home() {
+  const getNavData = useRecoilState(userNavAtom);
+  const setNavData = useSetRecoilState(userNavAtom);
+  useState(() => {
+    setNavData({
+      ...getNavData,
+      activeNavType: 'NOTICE',
+    });
+  });
   useEffect(() => {
     document.body.style.overflow = 'hidden';
     return () => {


### PR DESCRIPTION
## Issue

- Resolves #204 

## Description

- 바텀 네비 바 캘린더와 마이페이지에 추가
- 바텀 네비 바 포커스 되었을 때, 파란색으로 변경되지 않던 버그 수정
- 캘린더에서 달력 바깥쪽 부분 선택 시, -1 값으로 선택되는 버그 수정
- 내 정보에서 패딩 잘못 걸려있던 버그 수정
- 설정에서 상단 유틸리티헤더 안걸려있던 버그 수정
---
- 바텀 네비가 계속 뜨는 것처럼 보여서 혹시 이거 한번만 뜨도록 하는건 어떤가요?

## Check List

- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] PR에 해당되는 Issue를 연결 완료
- [x] 적절한 라벨 설정
- [x] 작업한 사람 모두를 Assign
- [x] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인

## Screenshot
![스크린샷 2024-03-16 오전 1 08 48](https://github.com/DaITssu/daitssu-client/assets/96258104/b3a6a319-ea4a-4520-bb6d-6c45c11ba648)
![스크린샷 2024-03-16 오전 1 09 10](https://github.com/DaITssu/daitssu-client/assets/96258104/39d5a521-98ab-49e7-a09a-9be0b74d64b1)
![스크린샷 2024-03-16 오전 1 09 24](https://github.com/DaITssu/daitssu-client/assets/96258104/a6f70ac9-f194-4e96-a676-2d58db0ec521)
![스크린샷 2024-03-16 오전 1 09 35](https://github.com/DaITssu/daitssu-client/assets/96258104/733c3a31-362f-4fbd-aaff-f2dd4ae9faca)
